### PR TITLE
feat(notifications): Add sync support to Notification model

### DIFF
--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\NotificationType;
+use App\Traits\Syncable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,7 +24,7 @@ use OpenApi\Attributes as OA;
 )]
 class Notification extends Model
 {
-    use HasFactory;
+    use HasFactory, Syncable;
 
     protected $fillable = [
         'user_id',
@@ -39,6 +40,8 @@ class Notification extends Model
         'read_at' => 'datetime',
         'type' => NotificationType::class,
     ];
+
+    protected $appends = ['last_synced_at', 'client_generated_id'];
 
     public function user(): BelongsTo
     {

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -936,13 +936,13 @@
                 "operationId": "3a9d6c015f72a79b135f274d58527133",
                 "parameters": [
                     {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "default": 20
-                        }
+                        "$ref": "#/components/parameters/limitParam"
+                    },
+                    {
+                        "$ref": "#/components/parameters/syncedSinceParam"
+                    },
+                    {
+                        "$ref": "#/components/parameters/noClientIdParam"
                     },
                     {
                         "name": "unread_only",
@@ -960,6 +960,10 @@
                             "application/json": {
                                 "schema": {
                                     "properties": {
+                                        "last_sync": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
                                         "data": {
                                             "type": "array",
                                             "items": {


### PR DESCRIPTION
Add Syncable trait and ApiQueryable to enable offline-first sync for notifications. The index endpoint now supports synced_since and no_client_id query parameters.