### PR TITLE
fix(sync): Set updated_at to match client-provided created_at

### DIFF
--- a/app/Traits/HasClientCreatedAt.php
+++ b/app/Traits/HasClientCreatedAt.php
@@ -16,6 +16,7 @@ trait HasClientCreatedAt
                 try {
                     $parsed = Carbon::parse($input);
                     $model->created_at = $parsed;
+                    $model->updated_at = $parsed;
 
                     Log::info('[Sync] Setting created_at from client', [
                         'model' => class_basename($model),


### PR DESCRIPTION
When clients provide created_at during record creation, also set updated_at to the same value to prevent timestamp mismatches caused by server/client timezone differences.