### PR TITLE
fix(openapi): Use multipart/form-data for transaction file uploads

### DIFF
--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -98,28 +98,43 @@ class TransactionController extends ApiController
         summary: 'Add file to a transaction',
         requestBody: new OA\RequestBody(
             required: true,
-            content: new OA\JsonContent(
-                required: ['files', 'type'],
-                properties: [
-                    new OA\Property(
-                        property: 'files',
-                        description: 'Files to attach to this transaction',
-                        type: 'array',
-                        items: new OA\Items(type: 'string', format: 'binary')
-                    ),
-                ]
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(
+                            property: 'files[]',
+                            description: 'Files to attach (jpg, jpeg, png, pdf; max 1MB each)',
+                            type: 'array',
+                            items: new OA\Items(type: 'string', format: 'binary')
+                        ),
+                    ]
+                )
             )
         ),
         tags: ['Transactions'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                description: 'ID of the transaction',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'integer')
+            ),
+        ],
         responses: [
             new OA\Response(
-                response: 201,
-                description: 'Transaction updated successfully',
+                response: 200,
+                description: 'Files uploaded successfully',
                 content: new OA\JsonContent(ref: '#/components/schemas/Transaction')
             ),
             new OA\Response(
-                response: 400,
-                description: 'Invalid input'
+                response: 404,
+                description: 'Transaction not found'
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation error'
             ),
         ]
     )]
@@ -157,30 +172,34 @@ class TransactionController extends ApiController
         summary: 'Create a new transaction',
         requestBody: new OA\RequestBody(
             required: true,
-            content: new OA\JsonContent(
-                required: ['amount', 'type'],
-                properties: [
-                    new OA\Property(property: 'client_id', description: 'Unique identifier for your local client', type: 'string',
-                        format: 'string', example: '245cb3df-df3a-428b-a908-e5f74b8d58a3:245cb3df-df3a-428b-a908-e5f74b8d58a4'),
-                    new OA\Property(property: 'amount', type: 'number', format: 'float'),
-                    new OA\Property(property: 'type', type: 'string', enum: ['income', 'expense']),
-                    new OA\Property(property: 'description', type: 'string'),
-                    new OA\Property(property: 'datetime', type: 'string', format: 'datetime'),
-                    new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
-                    new OA\Property(property: 'party_id', type: 'integer'),
-                    new OA\Property(property: 'wallet_id', type: 'integer'),
-                    new OA\Property(property: 'group_id', type: 'integer'),
-                    new OA\Property(property: 'is_recurring', description: 'Set the transaction as a recurring transaction', type: 'boolean'),
-                    new OA\Property(property: 'recurrence_period', description: 'Set how often the transaction should repeat', type: 'string'),
-                    new OA\Property(property: 'recurrence_interval', description: 'Set how often the transaction should repeat', type: 'integer'),
-                    new OA\Property(property: 'recurrence_ends_at', description: 'When the transaction stops repeating', type: 'date-time'),
-                    new OA\Property(property: 'categories', type: 'array', items: new OA\Items(description: 'Category ID array', type: 'integer')),
-                    new OA\Property(
-                        property: 'files',
-                        description: 'Files to attach to this transaction',
-                        type: 'array',
-                        items: new OA\Items(type: 'string', format: 'binary')
-                    )]
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    required: ['amount', 'type', 'wallet_id'],
+                    properties: [
+                        new OA\Property(property: 'client_id', description: 'Unique identifier for your local client', type: 'string',
+                            example: '245cb3df-df3a-428b-a908-e5f74b8d58a3:245cb3df-df3a-428b-a908-e5f74b8d58a4'),
+                        new OA\Property(property: 'amount', type: 'number', format: 'float'),
+                        new OA\Property(property: 'type', type: 'string', enum: ['income', 'expense']),
+                        new OA\Property(property: 'description', type: 'string'),
+                        new OA\Property(property: 'datetime', type: 'string', format: 'date-time'),
+                        new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
+                        new OA\Property(property: 'party_id', type: 'integer'),
+                        new OA\Property(property: 'wallet_id', type: 'integer'),
+                        new OA\Property(property: 'group_id', type: 'integer'),
+                        new OA\Property(property: 'is_recurring', description: 'Set the transaction as a recurring transaction', type: 'boolean'),
+                        new OA\Property(property: 'recurrence_period', description: 'Set how often the transaction should repeat', type: 'string', enum: ['daily', 'weekly', 'monthly', 'yearly']),
+                        new OA\Property(property: 'recurrence_interval', description: 'Set how often the transaction should repeat', type: 'integer'),
+                        new OA\Property(property: 'recurrence_ends_at', description: 'When the transaction stops repeating', type: 'string', format: 'date-time'),
+                        new OA\Property(property: 'categories', type: 'array', items: new OA\Items(description: 'Category ID', type: 'integer')),
+                        new OA\Property(
+                            property: 'files[]',
+                            description: 'Files to attach (jpg, jpeg, png, pdf; max 1.2MB each)',
+                            type: 'array',
+                            items: new OA\Items(type: 'string', format: 'binary')
+                        ),
+                    ]
+                )
             )
         ),
         tags: ['Transactions'],
@@ -193,6 +212,10 @@ class TransactionController extends ApiController
             new OA\Response(
                 response: 400,
                 description: 'Invalid input'
+            ),
+            new OA\Response(
+                response: 403,
+                description: 'Resource does not belong to user'
             ),
         ]
     )]

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2053,17 +2053,17 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
                                 "required": [
                                     "amount",
-                                    "type"
+                                    "type",
+                                    "wallet_id"
                                 ],
                                 "properties": {
                                     "client_id": {
                                         "description": "Unique identifier for your local client",
                                         "type": "string",
-                                        "format": "string",
                                         "example": "245cb3df-df3a-428b-a908-e5f74b8d58a3:245cb3df-df3a-428b-a908-e5f74b8d58a4"
                                     },
                                     "amount": {
@@ -2082,7 +2082,7 @@
                                     },
                                     "datetime": {
                                         "type": "string",
-                                        "format": "datetime"
+                                        "format": "date-time"
                                     },
                                     "created_at": {
                                         "type": "string",
@@ -2103,7 +2103,13 @@
                                     },
                                     "recurrence_period": {
                                         "description": "Set how often the transaction should repeat",
-                                        "type": "string"
+                                        "type": "string",
+                                        "enum": [
+                                            "daily",
+                                            "weekly",
+                                            "monthly",
+                                            "yearly"
+                                        ]
                                     },
                                     "recurrence_interval": {
                                         "description": "Set how often the transaction should repeat",
@@ -2111,17 +2117,18 @@
                                     },
                                     "recurrence_ends_at": {
                                         "description": "When the transaction stops repeating",
-                                        "type": "date-time"
+                                        "type": "string",
+                                        "format": "date-time"
                                     },
                                     "categories": {
                                         "type": "array",
                                         "items": {
-                                            "description": "Category ID array",
+                                            "description": "Category ID",
                                             "type": "integer"
                                         }
                                     },
-                                    "files": {
-                                        "description": "Files to attach to this transaction",
+                                    "files[]": {
+                                        "description": "Files to attach (jpg, jpeg, png, pdf; max 1.2MB each)",
                                         "type": "array",
                                         "items": {
                                             "type": "string",
@@ -2147,6 +2154,9 @@
                     },
                     "400": {
                         "description": "Invalid input"
+                    },
+                    "403": {
+                        "description": "Resource does not belong to user"
                     }
                 }
             }
@@ -2158,18 +2168,25 @@
                 ],
                 "summary": "Add file to a transaction",
                 "operationId": "c4819a10dcfa436a030128ac45465ae2",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the transaction",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/json": {
+                        "multipart/form-data": {
                             "schema": {
-                                "required": [
-                                    "files",
-                                    "type"
-                                ],
                                 "properties": {
-                                    "files": {
-                                        "description": "Files to attach to this transaction",
+                                    "files[]": {
+                                        "description": "Files to attach (jpg, jpeg, png, pdf; max 1MB each)",
                                         "type": "array",
                                         "items": {
                                             "type": "string",
@@ -2183,8 +2200,8 @@
                     }
                 },
                 "responses": {
-                    "201": {
-                        "description": "Transaction updated successfully",
+                    "200": {
+                        "description": "Files uploaded successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2193,8 +2210,11 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "Invalid input"
+                    "404": {
+                        "description": "Transaction not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
                     }
                 }
             }


### PR DESCRIPTION
Change content type from JsonContent to MediaType with multipart/form-data for endpoints that accept file uploads. Also add missing path parameter and correct response codes.