### PR TITLE
feat(api): Add file access endpoint with link attribute

### DIFF
--- a/app/Http/Controllers/API/v1/FileController.php
+++ b/app/Http/Controllers/API/v1/FileController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Http\Controllers\API\ApiController;
+use App\Models\File;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use OpenApi\Attributes as OA;
+
+#[OA\Tag(name: 'Files', description: 'Endpoints for accessing files')]
+class FileController extends ApiController
+{
+    #[OA\Get(
+        path: '/files/{id}',
+        summary: 'Get a file by ID',
+        tags: ['Files'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                description: 'ID of the file',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'integer')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'File content',
+                content: new OA\MediaType(
+                    mediaType: 'application/octet-stream',
+                    schema: new OA\Schema(type: 'string', format: 'binary')
+                )
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'File not found'
+            ),
+            new OA\Response(
+                response: 403,
+                description: 'Unauthorized access'
+            ),
+        ]
+    )]
+    public function show(Request $request, int $id)
+    {
+        $file = File::find($id);
+
+        if (! $file) {
+            return $this->failure(__('File not found'), 404);
+        }
+
+        $fileable = $file->fileable;
+
+        if (! $fileable || ! method_exists($fileable, 'user')) {
+            return $this->failure(__('Unable to verify file ownership'), 403);
+        }
+
+        if (optional($fileable->user)->id !== $request->user()->id) {
+            return $this->failure(__('You are not authorized to access this file'), 403);
+        }
+
+        if (! Storage::exists($file->path)) {
+            return $this->failure(__('File not found on storage'), 404);
+        }
+
+        return Storage::response($file->path);
+    }
+}

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -12,6 +12,7 @@ use OpenApi\Attributes as OA;
     properties: [
         new OA\Property(property: 'id', description: 'ID of the file', type: 'integer'),
         new OA\Property(property: 'path', description: 'Path or content of the file', type: 'string'),
+        new OA\Property(property: 'link', description: 'URL to access the file', type: 'string'),
         new OA\Property(property: 'type', description: 'Type of file (image, icon, emoji, pdf)', type: 'string', enum: ['image', 'pdf', 'icon', 'emoji']),
         new OA\Property(property: 'model', description: 'Related model name', type: 'string'),
         new OA\Property(property: 'model_id', description: 'ID of the related model', type: 'integer'),
@@ -24,9 +25,20 @@ class File extends Model
 
     protected $fillable = ['path', 'type', 'fileable_type', 'fileable_id'];
 
+    protected $appends = ['link'];
+
     protected $casts = [
         'model_id' => 'integer',
     ];
+
+    public function getLinkAttribute(): ?string
+    {
+        if (! $this->id) {
+            return null;
+        }
+
+        return url("/api/v1/files/{$this->id}");
+    }
 
     /**
      * Get the owning fileable model.

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -496,6 +496,45 @@
                 }
             }
         },
+        "/files/{id}": {
+            "get": {
+                "tags": [
+                    "Files"
+                ],
+                "summary": "Get a file by ID",
+                "operationId": "af81c42fa385fdeeac3331249ee4d7b0",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the file",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "File content",
+                        "content": {
+                            "application/octet-stream": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "File not found"
+                    },
+                    "403": {
+                        "description": "Unauthorized access"
+                    }
+                }
+            }
+        },
         "/groups": {
             "get": {
                 "tags": [
@@ -3674,6 +3713,10 @@
                         "description": "Path or content of the file",
                         "type": "string"
                     },
+                    "link": {
+                        "description": "URL to access the file",
+                        "type": "string"
+                    },
                     "type": {
                         "description": "Type of file (image, icon, emoji, pdf)",
                         "type": "string",
@@ -4210,6 +4253,10 @@
         {
             "name": "Category",
             "description": "Endpoints for managing transaction categories"
+        },
+        {
+            "name": "Files",
+            "description": "Endpoints for accessing files"
         },
         {
             "name": "Notifications",

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\API\v1\AiController;
 use App\Http\Controllers\API\v1\CategoryController;
+use App\Http\Controllers\API\v1\FileController;
 use App\Http\Controllers\API\v1\GroupController;
 use App\Http\Controllers\API\v1\ImportController;
 use App\Http\Controllers\API\v1\NotificationController;
@@ -43,6 +44,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['auth:sanctum']], function () {
     Route::apiResource('transactions', TransactionController::class);
     Route::post('/transactions/{id}/files', [TransactionController::class, 'uploadFiles']);
     Route::delete('/transactions/{id}/files/{file_id}', [TransactionController::class, 'deleteFiles']);
+    Route::get('/files/{id}', [FileController::class, 'show']);
     Route::post('categories/seed-defaults', [CategoryController::class, 'seedDefaults']);
     Route::apiResource('categories', CategoryController::class);
 

--- a/tests/Feature/FileControllerTest.php
+++ b/tests/Feature/FileControllerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FileControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $user;
+
+    private $wallet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+
+        $this->user = User::factory()->create();
+
+        $this->wallet = $this->user->wallets()->create([
+            'name' => 'Wallet',
+            'balance' => 1000,
+        ]);
+    }
+
+    public function test_file_response_includes_link_attribute()
+    {
+        $imageFile = UploadedFile::fake()->image('receipt.png');
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'files' => [$imageFile],
+        ]);
+
+        $response->assertStatus(201);
+
+        $files = $response->json('data.files');
+        $this->assertCount(1, $files);
+        $this->assertArrayHasKey('link', $files[0]);
+        $this->assertStringContainsString('/api/v1/files/', $files[0]['link']);
+    }
+
+    public function test_authenticated_user_can_access_their_file()
+    {
+        $imageFile = UploadedFile::fake()->image('receipt.png');
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'files' => [$imageFile],
+        ]);
+
+        $response->assertStatus(201);
+
+        $fileId = $response->json('data.files.0.id');
+        $filePath = $response->json('data.files.0.path');
+
+        $this->assertNotNull($fileId, 'File ID should not be null');
+        $this->assertNotNull($filePath, 'File path should not be null');
+
+        Storage::assertExists($filePath);
+
+        $response = $this->actingAs($this->user)->get("/api/v1/files/{$fileId}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_unauthenticated_user_cannot_access_files()
+    {
+        $imageFile = UploadedFile::fake()->image('receipt.png');
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'files' => [$imageFile],
+        ]);
+
+        $response->assertStatus(201);
+
+        $fileId = $response->json('data.files.0.id');
+
+        auth()->forgetGuards();
+
+        $response = $this->get("/api/v1/files/{$fileId}");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_user_cannot_access_another_users_file()
+    {
+        $anotherUser = User::factory()->create();
+        $anotherWallet = $anotherUser->wallets()->create([
+            'name' => 'Another Wallet',
+            'balance' => 500,
+        ]);
+
+        $imageFile = UploadedFile::fake()->image('receipt.png');
+
+        $response = $this->actingAs($anotherUser)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $anotherWallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'files' => [$imageFile],
+        ]);
+
+        $response->assertStatus(201);
+
+        $fileId = $response->json('data.files.0.id');
+
+        $response = $this->actingAs($this->user)->get("/api/v1/files/{$fileId}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_returns_404_for_non_existent_file()
+    {
+        $response = $this->actingAs($this->user)->get('/api/v1/files/99999');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_returns_404_when_file_missing_from_storage()
+    {
+        $imageFile = UploadedFile::fake()->image('receipt.png');
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'files' => [$imageFile],
+        ]);
+
+        $response->assertStatus(201);
+
+        $fileId = $response->json('data.files.0.id');
+        $filePath = $response->json('data.files.0.path');
+
+        Storage::delete($filePath);
+
+        $response = $this->actingAs($this->user)->get("/api/v1/files/{$fileId}");
+
+        $response->assertStatus(404)
+            ->assertJson([
+                'success' => false,
+                'message' => 'File not found on storage',
+            ]);
+    }
+}


### PR DESCRIPTION
Add GET /api/v1/files/{id} endpoint to serve uploaded files with ownership verification. Files now include a 'link' attribute in API responses for direct access.