### PR TITLE
fix: Order transactions and transfers by datetime desc, created_at desc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ phpstan: ## Static Analyzer
 	HOST_UID=$(HOST_UID) HOST_GID=$(HOST_GID) docker compose exec --user www-data app composer phpstan
 
 lint: ## Lint the code
+	HOST_UID=$(HOST_UID) HOST_GID=$(HOST_GID) docker compose exec --user www-data app composer phpcs:test
+	HOST_UID=$(HOST_UID) HOST_GID=$(HOST_GID) docker compose exec --user www-data app composer phpmd
 	HOST_UID=$(HOST_UID) HOST_GID=$(HOST_GID) docker compose exec --user www-data app composer pint:test
 
 lint-fix: ## Fix linting errors

--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -79,7 +79,7 @@ class TransactionController extends ApiController
 
         /** @var \App\Models\User $user */
         $user = auth()->user();
-        $query = $user->transactions()->orderBy('created_at', 'desc');
+        $query = $user->transactions()->orderBy('datetime', 'desc')->orderBy('created_at', 'desc');
         if (! empty($type)) {
             $query->where('type', $type);
         }

--- a/app/Http/Controllers/API/v1/TransferController.php
+++ b/app/Http/Controllers/API/v1/TransferController.php
@@ -57,7 +57,7 @@ class TransferController extends ApiController
     public function index(Request $request): JsonResponse
     {
         $user = $request->user();
-        $query = $user->transfers()->orderBy('created_at', 'desc');
+        $query = $user->transfers()->orderBy('datetime', 'desc')->orderBy('created_at', 'desc');
 
         try {
             $data = $this->applyApiQuery($request, $query, with_deleted: false);
@@ -87,6 +87,7 @@ class TransferController extends ApiController
                     new OA\Property(property: 'from_wallet_id', type: 'integer', example: 1),
                     new OA\Property(property: 'to_wallet_id', type: 'integer', example: 1),
                     new OA\Property(property: 'exchange_rate', type: 'number', format: 'float', example: 9.23),
+                    new OA\Property(property: 'datetime', type: 'string', format: 'date-time'),
                     new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
 
                 ]
@@ -117,6 +118,7 @@ class TransferController extends ApiController
             'exchange_rate' => 'sometimes|numeric|min:0.01',
             'from_wallet_id' => 'required|integer|exists:wallets,id',
             'to_wallet_id' => 'required|integer|exists:wallets,id',
+            'datetime' => ['nullable', new Iso8601DateTime()],
             'created_at' => ['nullable', new Iso8601DateTime()],
         ]);
 
@@ -157,6 +159,8 @@ class TransferController extends ApiController
 
         $amountToReceive = bcmul($data['amount'], $exchangeRate);
 
+        $datetime = isset($data['datetime']) ? format_iso8601_to_sql($data['datetime']) : null;
+
         $fullClientId = $data['client_id'] ?? null;
         $deviceToken = null;
         $randomId = null;
@@ -173,7 +177,8 @@ class TransferController extends ApiController
             $user,
             $exchangeRate,
             $deviceToken,
-            $randomId
+            $randomId,
+            $datetime
         ) {
             $transfer = $this->transferService->transfer(
                 amountToSend: $data['amount'],
@@ -182,7 +187,8 @@ class TransferController extends ApiController
                 toWallet: $toWallet,
                 user: $user,
                 exchangeRate: $exchangeRate,
-                deviceToken: $deviceToken
+                deviceToken: $deviceToken,
+                datetime: $datetime
             );
 
             if ($randomId && $deviceToken) {

--- a/app/Models/Transfer.php
+++ b/app/Models/Transfer.php
@@ -19,6 +19,12 @@ use OpenApi\Attributes as OA;
         new OA\Property(property: 'to_wallet_id', description: 'Destination wallet', type: 'integer'),
         new OA\Property(property: 'exchange_rate', description: 'The exchange rate', type: 'number', format: 'float'),
         new OA\Property(property: 'user_id', description: 'ID of the user', type: 'integer'),
+        new OA\Property(
+            property: 'datetime',
+            description: 'Date and time of the transfer',
+            type: 'string',
+            format: 'date-time'
+        ),
     ],
     type: 'object'
 )]
@@ -39,6 +45,11 @@ class Transfer extends Model
         'user_id',
         'from_wallet_id',
         'to_wallet_id',
+        'datetime',
+    ];
+
+    protected $casts = [
+        'datetime' => 'datetime',
     ];
 
     protected $appends = ['source_wallet', 'destination_wallet', 'last_synced_at', 'client_generated_id'];

--- a/app/Services/TransferService.php
+++ b/app/Services/TransferService.php
@@ -18,11 +18,14 @@ class TransferService
         Wallet $toWallet,
         User $user,
         float $exchangeRate,
-        ?string $deviceToken = null
+        ?string $deviceToken = null,
+        ?string $datetime = null
     ) {
         if ($fromWallet->balance < $amountToSend) {
             throw new InvalidArgumentException(__('Insufficient balance in source wallet'));
         }
+
+        $transferDatetime = $datetime ?? now();
 
         $transfer = Transfer::create([
             'amount' => $amountToSend,
@@ -30,6 +33,7 @@ class TransferService
             'to_wallet_id' => $toWallet->id,
             'user_id' => $user->id,
             'exchange_rate' => $exchangeRate,
+            'datetime' => $transferDatetime,
         ]);
 
         $fromWallet->balance -= $amountToSend;
@@ -37,7 +41,7 @@ class TransferService
 
         $expenseTransaction = $user->transactions()->create([
             'amount' => $amountToSend,
-            'datetime' => now(),
+            'datetime' => $transferDatetime,
             'type' => TransactionType::EXPENSE->value,
             'description' => "Money transfer from $fromWallet->currency wallet to $toWallet->currency wallet",
             'wallet_id' => $fromWallet->id,
@@ -49,7 +53,7 @@ class TransferService
 
         $incomeTransaction = $user->transactions()->create([
             'amount' => $amountToReceive,
-            'datetime' => now(),
+            'datetime' => $transferDatetime,
             'type' => TransactionType::INCOME->value,
             'description' => "Money transfer from $fromWallet->currency wallet to $toWallet->currency wallet",
             'wallet_id' => $toWallet->id,

--- a/database/migrations/2024_07_20_125115_create_transfers_table.php
+++ b/database/migrations/2024_07_20_125115_create_transfers_table.php
@@ -17,6 +17,7 @@ return new class () extends Migration {
             $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('from_wallet_id');
             $table->unsignedBigInteger('to_wallet_id');
+            $table->timestamp('datetime')->nullable();
             $table->timestamps();
 
             $table->foreign('to_wallet_id')->references('id')->on('wallets')->onDelete('cascade');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
 
     mysql-test:
         image: 'mysql:8.0'
-        ports:
-            - '${FORWARD_TEST_DB_PORT:-3307}:3306'
         environment:
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
             MYSQL_DATABASE: 'trakli_test'

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2569,6 +2569,10 @@
                                         "format": "float",
                                         "example": 9.23
                                     },
+                                    "datetime": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
                                     "created_at": {
                                         "type": "string",
                                         "format": "date-time"
@@ -4135,6 +4139,11 @@
                     "user_id": {
                         "description": "ID of the user",
                         "type": "integer"
+                    },
+                    "datetime": {
+                        "description": "Date and time of the transfer",
+                        "type": "string",
+                        "format": "date-time"
                     }
                 },
                 "type": "object"

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -276,6 +276,74 @@ class TransactionsTest extends TestCase
             ->assertJsonCount(2, 'data.data');
     }
 
+    public function test_transactions_are_ordered_by_datetime_then_created_at()
+    {
+        // Create transactions with different datetime values
+        $oldest = $this->user->transactions()->create([
+            'type' => 'expense',
+            'amount' => 10,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-01-01 00:00:00',
+            'created_at' => '2025-04-01 00:00:00',
+        ]);
+
+        $newest = $this->user->transactions()->create([
+            'type' => 'expense',
+            'amount' => 30,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-03-01 00:00:00',
+            'created_at' => '2025-04-01 00:00:00',
+        ]);
+
+        $middle = $this->user->transactions()->create([
+            'type' => 'expense',
+            'amount' => 20,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-02-01 00:00:00',
+            'created_at' => '2025-04-03 00:00:00',
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/transactions?type=expense');
+        $response->assertStatus(200);
+
+        $data = $response->json('data.data');
+
+        // Should be ordered by datetime desc: newest (Mar), middle (Feb), oldest (Jan)
+        $this->assertEquals($newest->id, $data[0]['id']);
+        $this->assertEquals($middle->id, $data[1]['id']);
+        $this->assertEquals($oldest->id, $data[2]['id']);
+    }
+
+    public function test_transactions_with_same_datetime_are_ordered_by_created_at()
+    {
+        $sameDate = '2025-06-15 12:00:00';
+
+        $first = $this->user->transactions()->create([
+            'type' => 'expense',
+            'amount' => 10,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => $sameDate,
+            'created_at' => '2025-06-15 10:00:00',
+        ]);
+
+        $second = $this->user->transactions()->create([
+            'type' => 'expense',
+            'amount' => 20,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => $sameDate,
+            'created_at' => '2025-06-15 14:00:00',
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/transactions?type=expense');
+        $response->assertStatus(200);
+
+        $data = $response->json('data.data');
+
+        // Same datetime, so ordered by created_at desc: second then first
+        $this->assertEquals($second->id, $data[0]['id']);
+        $this->assertEquals($first->id, $data[1]['id']);
+    }
+
     public function test_api_user_can_update_their_transactions()
     {
         $expense = $this->createTransaction('expense');

--- a/tests/Feature/TransferTest.php
+++ b/tests/Feature/TransferTest.php
@@ -515,4 +515,47 @@ class TransferTest extends TestCase
 
         $updateResponse->assertStatus(404);
     }
+
+    public function test_transfer_stores_datetime_and_propagates_to_transactions()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000]);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 100,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+            'datetime' => '2025-06-15T10:30:00.000Z',
+        ]);
+
+        $response->assertStatus(201);
+
+        $transfer = Transfer::first();
+        $this->assertEquals('2025-06-15 10:30:00', $transfer->datetime->format('Y-m-d H:i:s'));
+
+        $expenseTransaction = Transaction::where('wallet_id', $fromWallet->id)->first();
+        $incomeTransaction = Transaction::where('wallet_id', $toWallet->id)->first();
+
+        $this->assertEquals('2025-06-15 10:30:00', $expenseTransaction->datetime->format('Y-m-d H:i:s'));
+        $this->assertEquals('2025-06-15 10:30:00', $incomeTransaction->datetime->format('Y-m-d H:i:s'));
+    }
+
+    public function test_transfer_without_datetime_defaults_to_now()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000]);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 100,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+        ]);
+
+        $response->assertStatus(201);
+
+        $transfer = Transfer::first();
+        $this->assertNotNull($transfer->datetime);
+    }
 }


### PR DESCRIPTION
Transactions were sorted only by created_at which doesn't reflect the actual transaction date. Now datetime is the primary sort key with created_at as tiebreaker. Adds datetime column to transfers table and propagates it to the associated transactions created by TransferService. Removes unnecessary host port mapping from mysql-test container.