### PR TITLE
feat: Prevent duplicate transactions during transfer sync

### DIFF
--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -23,11 +23,9 @@ class TransactionController extends ApiController
 {
     use ApiQueryable;
 
-    private RecurringTransactionService $recurringTransactionService;
-
-    public function __construct(RecurringTransactionService $recurring_transaction_service)
-    {
-        $this->recurringTransactionService = $recurring_transaction_service;
+    public function __construct(
+        private RecurringTransactionService $recurringTransactionService
+    ) {
     }
 
     #[OA\Get(
@@ -274,6 +272,15 @@ class TransactionController extends ApiController
         }
 
         $data = $validationResult['data'];
+        $user = $request->user();
+
+        if (! empty($data['client_id'])) {
+            $existingTransaction = Transaction::findByClientId($data['client_id'], $user);
+            if ($existingTransaction) {
+                return $this->success($existingTransaction, statusCode: 200);
+            }
+        }
+
         $recurringTransactionData = [];
 
         if (isset($data['is_recurring']) && $data['is_recurring']) {
@@ -319,11 +326,10 @@ class TransactionController extends ApiController
             // Validate ownership of all resources before creating the transaction
             $this->validateResourceOwnership($data, $categories);
 
-            $transaction = DB::transaction(function () use ($request, $data, $categories, $recurringTransactionData) {
+            $transaction = DB::transaction(function () use ($request, $data, $categories, $recurringTransactionData, $user) {
                 /** @var Transaction $transaction */
-                $transaction = auth()->user()->transactions()->create($data);
+                $transaction = $user->transactions()->create($data);
 
-                $user = $request->user();
                 if (isset($data['client_id'])) {
                     $transaction->setClientGeneratedId($data['client_id'], $user);
                 }

--- a/app/Http/Controllers/API/v1/TransferController.php
+++ b/app/Http/Controllers/API/v1/TransferController.php
@@ -89,7 +89,16 @@ class TransferController extends ApiController
                     new OA\Property(property: 'exchange_rate', type: 'number', format: 'float', example: 9.23),
                     new OA\Property(property: 'datetime', type: 'string', format: 'date-time'),
                     new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
-
+                    new OA\Property(
+                        property: 'expense_transaction_client_id',
+                        description: 'Client ID of the expense transaction (for sync dedup)',
+                        type: 'string'
+                    ),
+                    new OA\Property(
+                        property: 'income_transaction_client_id',
+                        description: 'Client ID of the income transaction (for sync dedup)',
+                        type: 'string'
+                    ),
                 ]
             )
         ),
@@ -120,6 +129,8 @@ class TransferController extends ApiController
             'to_wallet_id' => 'required|integer|exists:wallets,id',
             'datetime' => ['nullable', new Iso8601DateTime()],
             'created_at' => ['nullable', new Iso8601DateTime()],
+            'expense_transaction_client_id' => ['nullable', 'string', new ValidateClientId()],
+            'income_transaction_client_id' => ['nullable', 'string', new ValidateClientId()],
         ]);
 
         if (! $validationResult['isValidated']) {
@@ -169,6 +180,11 @@ class TransferController extends ApiController
             $randomId = $parts[1];
         }
 
+        $transactionClientIds = array_filter([
+            'expense_transaction_client_id' => $data['expense_transaction_client_id'] ?? null,
+            'income_transaction_client_id' => $data['income_transaction_client_id'] ?? null,
+        ]);
+
         $transfer = DB::Transaction(function () use (
             $data,
             $toWallet,
@@ -178,7 +194,8 @@ class TransferController extends ApiController
             $exchangeRate,
             $deviceToken,
             $randomId,
-            $datetime
+            $datetime,
+            $transactionClientIds
         ) {
             $transfer = $this->transferService->transfer(
                 amountToSend: $data['amount'],
@@ -188,7 +205,8 @@ class TransferController extends ApiController
                 user: $user,
                 exchangeRate: $exchangeRate,
                 deviceToken: $deviceToken,
-                datetime: $datetime
+                datetime: $datetime,
+                transactionClientIds: $transactionClientIds
             );
 
             if ($randomId && $deviceToken) {

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use InvalidArgumentException;
 use OpenApi\Attributes as OA;
+use Whilesmart\UserDevices\Models\Device;
 
 #[OA\Schema(
     schema: 'Transaction',
@@ -201,6 +202,28 @@ class Transaction extends Model
     public function recurringTransactionRule(): HasOne
     {
         return $this->hasOne(RecurringTransactionRule::class);
+    }
+
+    public static function findByClientId(string $clientId, User $user): ?self
+    {
+        $parts = explode(':', $clientId);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $device = Device::where('token', $parts[0])->first();
+        if (! $device) {
+            return null;
+        }
+
+        return static::query()
+            ->where('user_id', $user->id)
+            ->join('model_sync_states', 'transactions.id', '=', 'model_sync_states.syncable_id')
+            ->where('model_sync_states.syncable_type', static::class)
+            ->where('model_sync_states.client_generated_id', $parts[1])
+            ->where('model_sync_states.device_id', $device->id)
+            ->select('transactions.*')
+            ->first();
     }
 
     public function delete()

--- a/app/Services/TransferService.php
+++ b/app/Services/TransferService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\TransactionType;
+use App\Models\Transaction;
 use App\Models\Transfer;
 use App\Models\User;
 use App\Models\Wallet;
@@ -11,6 +12,9 @@ use Ramsey\Uuid\Uuid;
 
 class TransferService
 {
+    /**
+     * @param  array{expense_transaction_client_id?: string|null, income_transaction_client_id?: string|null}  $transactionClientIds
+     */
     public function transfer(
         float $amountToSend,
         Wallet $fromWallet,
@@ -19,7 +23,8 @@ class TransferService
         User $user,
         float $exchangeRate,
         ?string $deviceToken = null,
-        ?string $datetime = null
+        ?string $datetime = null,
+        array $transactionClientIds = []
     ) {
         if ($fromWallet->balance < $amountToSend) {
             throw new InvalidArgumentException(__('Insufficient balance in source wallet'));
@@ -39,37 +44,63 @@ class TransferService
         $fromWallet->balance -= $amountToSend;
         $fromWallet->save();
 
-        $expenseTransaction = $user->transactions()->create([
-            'amount' => $amountToSend,
-            'datetime' => $transferDatetime,
-            'type' => TransactionType::EXPENSE->value,
-            'description' => "Money transfer from $fromWallet->currency wallet to $toWallet->currency wallet",
-            'wallet_id' => $fromWallet->id,
-            'transfer_id' => $transfer->id,
-        ]);
+        $expenseTransaction = $this->findOrCreateTransaction(
+            $transactionClientIds['expense_transaction_client_id'] ?? null,
+            $user,
+            [
+                'amount' => $amountToSend,
+                'datetime' => $transferDatetime,
+                'type' => TransactionType::EXPENSE->value,
+                'description' => "Money transfer from $fromWallet->currency wallet to $toWallet->currency wallet",
+                'wallet_id' => $fromWallet->id,
+                'transfer_id' => $transfer->id,
+            ]
+        );
 
         $toWallet->balance = bcadd($toWallet->balance, $amountToReceive, 4);
         $toWallet->save();
 
-        $incomeTransaction = $user->transactions()->create([
-            'amount' => $amountToReceive,
-            'datetime' => $transferDatetime,
-            'type' => TransactionType::INCOME->value,
-            'description' => "Money transfer from $fromWallet->currency wallet to $toWallet->currency wallet",
-            'wallet_id' => $toWallet->id,
-            'transfer_id' => $transfer->id,
-        ]);
+        $incomeTransaction = $this->findOrCreateTransaction(
+            $transactionClientIds['income_transaction_client_id'] ?? null,
+            $user,
+            [
+                'amount' => $amountToReceive,
+                'datetime' => $transferDatetime,
+                'type' => TransactionType::INCOME->value,
+                'description' => "Money transfer from $fromWallet->currency wallet to $toWallet->currency wallet",
+                'wallet_id' => $toWallet->id,
+                'transfer_id' => $transfer->id,
+            ]
+        );
 
         if ($deviceToken) {
-            $expenseRandomId = Uuid::uuid4()->toString();
-            $expenseTransaction->setClientGeneratedId($expenseRandomId, $user, $deviceToken);
+            if (! $expenseTransaction->client_generated_id) {
+                $expenseRandomId = Uuid::uuid4()->toString();
+                $expenseTransaction->setClientGeneratedId($expenseRandomId, $user, $deviceToken);
+            }
             $expenseTransaction->markAsSynced();
 
-            $incomeRandomId = Uuid::uuid4()->toString();
-            $incomeTransaction->setClientGeneratedId($incomeRandomId, $user, $deviceToken);
+            if (! $incomeTransaction->client_generated_id) {
+                $incomeRandomId = Uuid::uuid4()->toString();
+                $incomeTransaction->setClientGeneratedId($incomeRandomId, $user, $deviceToken);
+            }
             $incomeTransaction->markAsSynced();
         }
 
         return $transfer;
+    }
+
+    private function findOrCreateTransaction(?string $clientId, User $user, array $data): Transaction
+    {
+        if ($clientId) {
+            $existing = Transaction::findByClientId($clientId, $user);
+            if ($existing) {
+                $existing->update(['transfer_id' => $data['transfer_id']]);
+
+                return $existing;
+            }
+        }
+
+        return $user->transactions()->create($data);
     }
 }

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2576,6 +2576,14 @@
                                     "created_at": {
                                         "type": "string",
                                         "format": "date-time"
+                                    },
+                                    "expense_transaction_client_id": {
+                                        "description": "Client ID of the expense transaction (for sync dedup)",
+                                        "type": "string"
+                                    },
+                                    "income_transaction_client_id": {
+                                        "description": "Client ID of the income transaction (for sync dedup)",
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object"

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Artisan;
+use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 
 class TransactionsTest extends TestCase
@@ -1090,5 +1091,39 @@ class TransactionsTest extends TestCase
             'name' => 'Category',
             'type' => 'income',
         ]);
+    }
+
+    public function test_duplicate_transaction_with_same_client_id_returns_existing()
+    {
+        $deviceId = Uuid::uuid4()->toString();
+        $randomId = Uuid::uuid4()->toString();
+        $clientId = $deviceId . ':' . $randomId;
+
+        $firstResponse = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'description' => 'Test transaction',
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'client_id' => $clientId,
+        ]);
+
+        $firstResponse->assertStatus(201);
+        $firstId = $firstResponse->json('data.id');
+
+        $secondResponse = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'description' => 'Test transaction',
+            'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'client_id' => $clientId,
+        ]);
+
+        $secondResponse->assertStatus(200);
+        $secondId = $secondResponse->json('data.id');
+
+        $this->assertEquals($firstId, $secondId);
+        $this->assertEquals(1, Transaction::where('user_id', $this->user->id)->count());
     }
 }

--- a/tests/Feature/TransferTest.php
+++ b/tests/Feature/TransferTest.php
@@ -11,6 +11,7 @@ use App\Models\Wallet;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
+use Whilesmart\UserDevices\Models\Device;
 
 class TransferTest extends TestCase
 {
@@ -557,5 +558,92 @@ class TransferTest extends TestCase
 
         $transfer = Transfer::first();
         $this->assertNotNull($transfer->datetime);
+    }
+
+    public function test_transfer_with_expense_and_income_transaction_client_ids_links_existing_transactions()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000]);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id]);
+
+        $deviceToken = Uuid::uuid4()->toString();
+        $device = Device::create(['token' => $deviceToken, 'deviceable_id' => $user->id, 'deviceable_type' => get_class($user)]);
+
+        // Simulate transactions synced first (mobile created them before the transfer)
+        $expenseTransaction = $user->transactions()->create([
+            'amount' => 100,
+            'datetime' => now(),
+            'type' => TransactionType::EXPENSE->value,
+            'description' => 'Transfer expense',
+            'wallet_id' => $fromWallet->id,
+        ]);
+        $expenseRandomId = Uuid::uuid4()->toString();
+        $expenseTransaction->syncState()->updateOrCreate([], [
+            'client_generated_id' => $expenseRandomId,
+            'device_id' => $device->id,
+        ]);
+
+        $incomeTransaction = $user->transactions()->create([
+            'amount' => 100,
+            'datetime' => now(),
+            'type' => TransactionType::INCOME->value,
+            'description' => 'Transfer income',
+            'wallet_id' => $toWallet->id,
+        ]);
+        $incomeRandomId = Uuid::uuid4()->toString();
+        $incomeTransaction->syncState()->updateOrCreate([], [
+            'client_generated_id' => $incomeRandomId,
+            'device_id' => $device->id,
+        ]);
+
+        $transactionCountBefore = Transaction::where('user_id', $user->id)->count();
+
+        // Now sync the transfer with client IDs referencing the existing transactions
+        $response = $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 100,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+            'expense_transaction_client_id' => $deviceToken . ':' . $expenseRandomId,
+            'income_transaction_client_id' => $deviceToken . ':' . $incomeRandomId,
+        ]);
+
+        $response->assertStatus(201);
+
+        // No new transactions should have been created
+        $this->assertEquals($transactionCountBefore, Transaction::where('user_id', $user->id)->count());
+
+        // Existing transactions should now be linked to the transfer
+        $transfer = Transfer::first();
+        $expenseTransaction->refresh();
+        $incomeTransaction->refresh();
+
+        $this->assertEquals($transfer->id, $expenseTransaction->transfer_id);
+        $this->assertEquals($transfer->id, $incomeTransaction->transfer_id);
+    }
+
+    public function test_transfer_with_unknown_client_ids_creates_new_transactions()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000]);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id]);
+
+        $deviceToken = Uuid::uuid4()->toString();
+        $expenseClientId = $deviceToken . ':' . Uuid::uuid4()->toString();
+        $incomeClientId = $deviceToken . ':' . Uuid::uuid4()->toString();
+
+        $response = $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 100,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+            'expense_transaction_client_id' => $expenseClientId,
+            'income_transaction_client_id' => $incomeClientId,
+        ]);
+
+        $response->assertStatus(201);
+
+        // New transactions should be created since client IDs don't match existing ones
+        $transfer = Transfer::first();
+        $transactions = Transaction::where('transfer_id', $transfer->id)->get();
+        $this->assertCount(2, $transactions);
     }
 }


### PR DESCRIPTION
Two dedup mechanisms for mobile sync:
- TransferController accepts expense_client_id/income_client_id to link pre-existing transactions instead of creating new ones
- TransactionController deduplicates by client_id, returning existing transaction if already synced