### PR TITLE
chore(release): Bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-03-06
+
+### Added
+
+- Account deletion, admin endpoints, and CLI commands
+- Locale-based translation for default categories and groups
+- File access endpoint with link attribute on transactions
+- Index and update endpoints for transfers
+- Duplicate transaction prevention during transfer sync
+- Code coverage checks and test database configuration
+- Static analysis tooling (phpmd, phpstan, phpcs)
+
+### Fixed
+
+- Transactions and transfers now ordered by datetime desc, created_at desc
+- Flaky test failures in StatsControllerTest by freezing time
+- Integer ID handling via PDO options and wallet ID casting
+- Multipart/form-data encoding for transaction file uploads
+- Duplicate transfers prevented during mobile sync
+
+### Changed
+
+- Updated OpenAPI documentation
+- Customized phpcs rules for less aggressive linting
+
 ## [1.0.1] - 2025-01-18
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "trakli/webservice",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "type": "project",
     "description": "Trakli Webservice",
     "keywords": [


### PR DESCRIPTION
Update changelog with all changes since v1.0.1 including account deletion, transfer endpoints, locale translations, file access, static analysis tooling, and various bug fixes.