### PR TITLE
feat: Add advanced document importer with pluggable processors

### DIFF
--- a/app/Contracts/DocumentProcessor.php
+++ b/app/Contracts/DocumentProcessor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Models\User;
+use App\Types\TransactionSuggestion;
+use Illuminate\Http\UploadedFile;
+
+interface DocumentProcessor
+{
+    /**
+     * Determine if this processor can handle the given file type.
+     */
+    public function supports(string $mimeType, string $extension): bool;
+
+    /**
+     * Process a file and return an array of transaction suggestions.
+     *
+     * @return TransactionSuggestion[]
+     */
+    public function process(UploadedFile $file, User $user): array;
+}

--- a/app/Http/Controllers/API/v1/ImportController.php
+++ b/app/Http/Controllers/API/v1/ImportController.php
@@ -6,8 +6,15 @@ use App\Enums\TransactionType;
 use App\Http\Controllers\API\ApiController;
 use App\Http\Requests\FileImportApiRequest;
 use App\Http\Requests\FixFailedImportsRequest;
+use App\Http\Requests\ImportAnalyzeRequest;
+use App\Http\Requests\ImportConfirmRequest;
+use App\Jobs\AnalyzeImportJob;
 use App\Jobs\ImportFileJob;
+use App\Services\DocumentProcessorManager;
+use App\Services\DuplicateDetectionService;
 use App\Services\FileImportService;
+use App\Services\SuggestionEnricher;
+use App\Types\TransactionSuggestion;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -18,11 +25,12 @@ use OpenApi\Attributes as OA;
  */
 class ImportController extends ApiController
 {
-    private FileImportService $fileImportService;
-
-    public function __construct(FileImportService $fileImportService)
-    {
-        $this->fileImportService = $fileImportService;
+    public function __construct(
+        private FileImportService $fileImportService,
+        private DocumentProcessorManager $processorManager,
+        private SuggestionEnricher $enricher,
+        private DuplicateDetectionService $duplicateService,
+    ) {
     }
 
     #[OA\Post(
@@ -312,5 +320,225 @@ class ImportController extends ApiController
             $import['description'] ?? '',
             $import['date'] ?? '',
         ];
+    }
+
+    #[OA\Post(
+        path: '/import/analyze',
+        summary: 'Analyze a document and return transaction suggestions',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'file', type: 'string', format: 'binary'),
+                    new OA\Property(property: 'document_type', type: 'string', enum: ['bank_statement', 'receipt', 'invoice', 'pay_stub', 'utility_bill']),
+                ]
+            )
+        ),
+        tags: ['Import'],
+        responses: [
+            new OA\Response(response: 200, description: 'Suggestions returned'),
+            new OA\Response(response: 422, description: 'Validation error'),
+            new OA\Response(response: 500, description: 'Server error'),
+        ]
+    )]
+    public function analyze(ImportAnalyzeRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $file = $request->file('file');
+
+        try {
+            $mimeType = $file->getMimeType() ?? '';
+            $extension = strtolower($file->getClientOriginalExtension());
+
+            if (! $this->processorManager->canHandle($mimeType, $extension)) {
+                return $this->failure(__('No processor available for this file type.'), 422);
+            }
+
+            // Store file for background processing
+            $storedPath = $file->store('import-analyze');
+
+            $processor = $this->processorManager->getProcessor($mimeType, $extension);
+            $processorName = class_basename($processor);
+
+            $session = $user->importSessions()->create([
+                'file_name' => $file->getClientOriginalName(),
+                'file_type' => $extension,
+                'document_type' => $request->input('document_type'),
+                'processor' => $processorName,
+                'status' => 'analyzing',
+                'suggestions' => [],
+            ]);
+
+            AnalyzeImportJob::dispatch(
+                $session->id,
+                $storedPath,
+                $file->getClientOriginalName(),
+                $mimeType,
+                $extension,
+            );
+
+            return $this->success($session, __('Document uploaded. Analysis in progress.'));
+        } catch (\RuntimeException $e) {
+            return $this->failure($e->getMessage(), 422);
+        } catch (\Throwable $e) {
+            Log::error('Import analyze failed', ['error' => $e->getMessage()]);
+
+            return $this->failure(__('Failed to start document analysis.'));
+        }
+    }
+
+    #[OA\Post(
+        path: '/import/confirm',
+        summary: 'Confirm and create transactions from reviewed suggestions',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'session_id', type: 'integer'),
+                    new OA\Property(property: 'accepted', type: 'array', items: new OA\Items(type: 'object')),
+                ]
+            )
+        ),
+        tags: ['Import'],
+        responses: [
+            new OA\Response(response: 200, description: 'Transactions created'),
+            new OA\Response(response: 404, description: 'Session not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
+    public function confirm(ImportConfirmRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $session = $user->importSessions()->find($request->input('session_id'));
+
+        if (is_null($session)) {
+            return $this->failure(__('Import session not found.'), 404);
+        }
+
+        if ($session->status !== 'ready') {
+            return $this->failure(__('This import session has already been processed.'), 422);
+        }
+
+        $suggestions = $session->suggestions;
+        $accepted = $request->input('accepted');
+        $createdCount = 0;
+        $errors = [];
+
+        foreach ($accepted as $item) {
+            $result = $this->processAcceptedItem($item, $suggestions, $user);
+
+            if ($result === true) {
+                $createdCount++;
+            } elseif (is_string($result)) {
+                $errors[] = $result;
+            }
+        }
+
+        $session->update(['status' => 'confirmed']);
+
+        $data = [
+            'created_count' => $createdCount,
+            'errors' => $errors,
+        ];
+
+        if (! empty($errors)) {
+            return $this->success($data, __('Import completed with some errors.'), 206);
+        }
+
+        return $this->success($data, __('All transactions imported successfully.'));
+    }
+
+    /**
+     * Process a single accepted suggestion item.
+     *
+     * @return true|string True on success, error message string on failure
+     */
+    private function processAcceptedItem(array $item, array $suggestions, $user): true|string
+    {
+        $index = $item['index'];
+
+        if (! isset($suggestions[$index])) {
+            return "Invalid suggestion index: {$index}";
+        }
+
+        $suggestion = $this->mergeUserEdits($suggestions[$index], $item);
+        $transactionType = $suggestion['type'] ?? 'expense';
+
+        if (! in_array($transactionType, [TransactionType::EXPENSE->value, TransactionType::INCOME->value])) {
+            return "Invalid transaction type at index {$index}";
+        }
+
+        try {
+            $suggestionObj = TransactionSuggestion::fromArray($suggestion);
+            $this->fileImportService->importTransaction(
+                $suggestionObj->toImportArray(),
+                $transactionType,
+                $user
+            );
+
+            return true;
+        } catch (\Exception $e) {
+            Log::error('Import confirm failed for suggestion', [
+                'index' => $index,
+                'error' => $e->getMessage(),
+            ]);
+
+            return "Failed to import suggestion at index {$index}: {$e->getMessage()}";
+        }
+    }
+
+    /**
+     * Merge user edits into a suggestion array.
+     */
+    private function mergeUserEdits(array $suggestion, array $item): array
+    {
+        foreach (['amount', 'currency', 'type', 'party', 'wallet', 'category', 'description', 'date'] as $field) {
+            if (isset($item[$field])) {
+                $suggestion[$field] = $item[$field];
+            }
+        }
+
+        return $suggestion;
+    }
+
+    #[OA\Get(
+        path: '/import/sessions',
+        summary: 'Get all import sessions',
+        tags: ['Import'],
+        responses: [
+            new OA\Response(response: 200, description: 'Sessions list'),
+        ]
+    )]
+    public function getSessions(Request $request): JsonResponse
+    {
+        $sessions = $request->user()
+            ->importSessions()
+            ->orderBy('id', 'desc')
+            ->get();
+
+        return $this->success($sessions);
+    }
+
+    #[OA\Get(
+        path: '/import/sessions/{id}',
+        summary: 'Get a specific import session',
+        tags: ['Import'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Session details'),
+            new OA\Response(response: 404, description: 'Not found'),
+        ]
+    )]
+    public function getSession(Request $request, string $sessionId): JsonResponse
+    {
+        $session = $request->user()->importSessions()->find($sessionId);
+
+        if (is_null($session)) {
+            return $this->failure(__('Import session not found.'), 404);
+        }
+
+        return $this->success($session);
     }
 }

--- a/app/Http/Requests/ImportAnalyzeRequest.php
+++ b/app/Http/Requests/ImportAnalyzeRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportAnalyzeRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'file' => 'required|file|mimes:csv,pdf,png,jpg,jpeg,tiff,bmp|max:10240',
+            'document_type' => 'nullable|string|in:bank_statement,receipt,invoice,pay_stub,utility_bill',
+        ];
+    }
+}

--- a/app/Http/Requests/ImportConfirmRequest.php
+++ b/app/Http/Requests/ImportConfirmRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportConfirmRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'session_id' => 'required|integer|exists:import_sessions,id',
+            'accepted' => 'required|array|min:1',
+            'accepted.*.index' => 'required|integer|min:0',
+            'accepted.*.amount' => 'nullable|numeric',
+            'accepted.*.currency' => 'nullable|string',
+            'accepted.*.type' => 'nullable|string|in:income,expense',
+            'accepted.*.party' => 'nullable|string',
+            'accepted.*.wallet' => 'nullable|string',
+            'accepted.*.category' => 'nullable|string',
+            'accepted.*.description' => 'nullable|string',
+            'accepted.*.date' => 'nullable|date_format:Y-m-d',
+        ];
+    }
+}

--- a/app/Jobs/AnalyzeImportJob.php
+++ b/app/Jobs/AnalyzeImportJob.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ImportSession;
+use App\Services\DocumentProcessorManager;
+use App\Services\DuplicateDetectionService;
+use App\Services\SuggestionEnricher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class AnalyzeImportJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 1;
+
+    public function __construct(
+        private int $sessionId,
+        private string $storedFilePath,
+        private string $originalName,
+        private string $mimeType,
+        private string $extension,
+    ) {
+    }
+
+    public function handle(
+        DocumentProcessorManager $processorManager,
+        SuggestionEnricher $enricher,
+        DuplicateDetectionService $duplicateService,
+    ): void {
+        $session = ImportSession::find($this->sessionId);
+
+        if (! $session) {
+            Log::error('AnalyzeImportJob: session not found', ['id' => $this->sessionId]);
+            $this->cleanup();
+
+            return;
+        }
+
+        $user = $session->user;
+
+        try {
+            $filePath = Storage::path($this->storedFilePath);
+
+            if (! file_exists($filePath)) {
+                Log::error('AnalyzeImportJob: file not found', ['path' => $filePath]);
+                $session->update([
+                    'status' => 'failed',
+                    'metadata' => ['error' => 'Uploaded file not found'],
+                ]);
+
+                return;
+            }
+
+            $file = new UploadedFile($filePath, $this->originalName, $this->mimeType, null, true);
+
+            // Stage 1: Extracting
+            $session->update(['status' => 'extracting']);
+
+            $processor = $processorManager->getProcessor($this->mimeType, $this->extension);
+            $suggestions = $processor->process($file, $user);
+
+            if (empty($suggestions)) {
+                $session->update([
+                    'status' => 'failed',
+                    'metadata' => ['error' => 'No transactions could be extracted from this document.'],
+                ]);
+                $this->cleanup();
+
+                return;
+            }
+
+            // Stage 2: Enriching
+            $session->update(['status' => 'enriching']);
+
+            $suggestions = $enricher->enrich($suggestions, $user);
+
+            // Stage 3: Checking duplicates
+            $session->update(['status' => 'checking']);
+
+            $duplicates = $duplicateService->checkBatch($suggestions, $user);
+
+            // Build suggestions array with duplicate info
+            $suggestionsData = [];
+            foreach ($suggestions as $i => $suggestion) {
+                $entry = $suggestion->toArray();
+                $entry['duplicate'] = $duplicates[$i]?->toArray();
+                $suggestionsData[] = $entry;
+            }
+
+            $session->update([
+                'status' => 'ready',
+                'suggestions' => $suggestionsData,
+                'metadata' => [
+                    'total_suggestions' => count($suggestions),
+                    'duplicates_found' => count(array_filter($duplicates)),
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('AnalyzeImportJob failed', [
+                'session_id' => $this->sessionId,
+                'error' => $e->getMessage(),
+            ]);
+
+            $session->update([
+                'status' => 'failed',
+                'metadata' => ['error' => 'Analysis failed: ' . $e->getMessage()],
+            ]);
+        } finally {
+            $this->cleanup();
+        }
+    }
+
+    private function cleanup(): void
+    {
+        Storage::delete($this->storedFilePath);
+    }
+}

--- a/app/Models/ImportSession.php
+++ b/app/Models/ImportSession.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ImportSession extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'file_name',
+        'file_type',
+        'document_type',
+        'processor',
+        'status',
+        'suggestions',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'suggestions' => 'array',
+        'metadata' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -100,6 +100,11 @@ class User extends Authenticatable
         return $this->hasMany(FileImport::class);
     }
 
+    public function importSessions(): HasMany
+    {
+        return $this->hasMany(ImportSession::class);
+    }
+
     public function reminders(): HasMany
     {
         return $this->hasMany(Reminder::class);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Services\DocumentProcessorManager;
+use App\Services\DocumentProcessors\CsvProcessor;
+use App\Services\DocumentProcessors\RemoteDocumentProcessor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\ServiceProvider;
 use Kreait\Firebase\Contract\Messaging;
@@ -16,6 +19,14 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->register(PluginServiceProvider::class);
+
+        $this->app->singleton(DocumentProcessorManager::class, function ($app) {
+            $manager = new DocumentProcessorManager();
+            $manager->register($app->make(CsvProcessor::class));
+            $manager->register($app->make(RemoteDocumentProcessor::class));
+
+            return $manager;
+        });
 
         $this->app->bind(Messaging::class, function () {
             $credentials = config('firebase.credentials') ?? env('FIREBASE_CREDENTIALS');

--- a/app/Services/DocumentProcessorManager.php
+++ b/app/Services/DocumentProcessorManager.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\DocumentProcessor;
+use RuntimeException;
+
+class DocumentProcessorManager
+{
+    /** @var DocumentProcessor[] */
+    private array $processors = [];
+
+    public function register(DocumentProcessor $processor): void
+    {
+        $this->processors[] = $processor;
+    }
+
+    public function canHandle(string $mimeType, string $extension): bool
+    {
+        foreach ($this->processors as $processor) {
+            if ($processor->supports($mimeType, $extension)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function getProcessor(string $mimeType, string $extension): DocumentProcessor
+    {
+        foreach ($this->processors as $processor) {
+            if ($processor->supports($mimeType, $extension)) {
+                return $processor;
+            }
+        }
+
+        throw new RuntimeException("No document processor available for type: {$mimeType} ({$extension})");
+    }
+}

--- a/app/Services/DocumentProcessors/CsvProcessor.php
+++ b/app/Services/DocumentProcessors/CsvProcessor.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Services\DocumentProcessors;
+
+use App\Contracts\DocumentProcessor;
+use App\Enums\TransactionType;
+use App\Models\User;
+use App\Services\FileImportService;
+use App\Types\TransactionSuggestion;
+use Illuminate\Http\UploadedFile;
+
+class CsvProcessor implements DocumentProcessor
+{
+    public function __construct(
+        private FileImportService $fileImportService,
+    ) {
+    }
+
+    public function supports(string $mimeType, string $extension): bool
+    {
+        return $extension === 'csv' || $mimeType === 'text/csv';
+    }
+
+    /**
+     * @return TransactionSuggestion[]
+     */
+    public function process(UploadedFile $file, User $user): array
+    {
+        $suggestions = [];
+        $path = $file->getRealPath();
+
+        if (! $path) {
+            return $suggestions;
+        }
+
+        $handle = fopen($path, 'r');
+        if ($handle === false) {
+            return $suggestions;
+        }
+
+        $isFirstRow = true;
+        while (($data = fgetcsv($handle)) !== false) {
+            if ($isFirstRow) {
+                $isFirstRow = false;
+
+                continue;
+            }
+
+            $transactionType = isset($data[2]) ? strtolower(trim($data[2])) : null;
+
+            // Skip transfer rows for now — the suggestion flow handles income/expense
+            if (! in_array($transactionType, [TransactionType::EXPENSE->value, TransactionType::INCOME->value])) {
+                $transactionType = null;
+            }
+
+            $date = $data[7] ?? null;
+            $confidence = 1.0;
+
+            if ($date && ! $this->fileImportService->isValidDate($date)) {
+                $confidence = 0.3;
+            }
+
+            $suggestions[] = new TransactionSuggestion(
+                amount: isset($data[0]) ? (float) $data[0] : null,
+                currency: $data[1] ?? null,
+                type: $transactionType,
+                party: $data[3] ?? null,
+                wallet: $data[4] ?? null,
+                category: $data[5] ?? null,
+                description: $data[6] ?? null,
+                date: $date,
+                confidence: $confidence,
+                documentType: 'csv',
+            );
+        }
+
+        fclose($handle);
+
+        return $suggestions;
+    }
+}

--- a/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
+++ b/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
@@ -1,0 +1,468 @@
+<?php
+
+namespace App\Services\DocumentProcessors;
+
+use App\Contracts\DocumentProcessor;
+use App\Models\User;
+use App\Types\TransactionSuggestion;
+use Carbon\Carbon;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Prism\Prism\Facades\Prism;
+
+/**
+ * Generic remote document processor.
+ *
+ * Sends files to any configured URL and parses the response using a
+ * configurable field mapping. Works with any document processing service.
+ *
+ * Configuration (config/services.php → 'document_processor'):
+ *   - url: The endpoint URL
+ *   - timeout: Request timeout in seconds
+ *   - auth_type: none|bearer|apikey|basic
+ *   - auth_credentials: Token, API key, or "user:pass"
+ *   - file_field: Form field name for the file (default: "file")
+ *   - extra_params: Additional form parameters to send
+ *   - response_mapping:
+ *       transactions_path: dot-notation path to the array of items (e.g. "transactions", "elements", "data.rows")
+ *       mode: "fields" (each item has named keys) or "text_block" (each item has a text blob to parse by line)
+ *       --- fields mode ---
+ *       date_field, description_field, amount_field, currency_field, type_field, party_field, category_field, confidence_field
+ *       --- text_block mode ---
+ *       content_field: key containing the text block (default: "content")
+ *       line_mapping: { date: 0, description: 1, amount: 2, currency: 3 } (line index per field)
+ *       filter: { key: "subtype", value: "paragraph" } (optional, only process items matching this)
+ */
+class RemoteDocumentProcessor implements DocumentProcessor
+{
+    private const SUPPORTED_EXTENSIONS = ['pdf', 'png', 'jpg', 'jpeg', 'tiff', 'tif', 'bmp'];
+
+    private const SUPPORTED_MIMES = [
+        'application/pdf',
+        'image/png',
+        'image/jpeg',
+        'image/tiff',
+        'image/bmp',
+    ];
+
+    public function supports(string $mimeType, string $extension): bool
+    {
+        $url = config('services.document_processor.url');
+
+        if (empty($url)) {
+            return false;
+        }
+
+        return in_array($extension, self::SUPPORTED_EXTENSIONS)
+            || in_array($mimeType, self::SUPPORTED_MIMES);
+    }
+
+    /**
+     * @return TransactionSuggestion[]
+     */
+    public function process(UploadedFile $file, User $user): array
+    {
+        $url = config('services.document_processor.url');
+
+        if (empty($url)) {
+            return [];
+        }
+
+        $response = $this->callRemote($file);
+
+        if ($response === null) {
+            return [];
+        }
+
+        $suggestions = $this->parseResponse($response);
+
+        // Fallback: if mapping couldn't extract transactions, send raw data to LLM
+        if (empty($suggestions)) {
+            $rawText = $this->extractRawText($response);
+            if (! empty($rawText)) {
+                Log::info('RemoteDocumentProcessor: mapping returned empty, falling back to LLM');
+                $suggestions = $this->extractViaLlm($rawText);
+            }
+        }
+
+        return $suggestions;
+    }
+
+    private function callRemote(UploadedFile $file): ?array
+    {
+        $url = config('services.document_processor.url');
+        $timeout = (int) config('services.document_processor.timeout', 120);
+        $fileField = config('services.document_processor.file_field', 'file');
+        $extraParams = config('services.document_processor.extra_params', []);
+
+        try {
+            $authType = config('services.document_processor.auth_type', 'none');
+            $credentials = config('services.document_processor.auth_credentials', '');
+            $authHeader = config('services.document_processor.auth_header', 'X-API-Key');
+
+            $fileHandle = fopen($file->getRealPath(), 'r');
+
+            try {
+                $request = Http::timeout($timeout)
+                    ->attach($fileField, $fileHandle, $file->getClientOriginalName());
+
+                if ($authType === 'bearer') {
+                    $request = $request->withToken($credentials);
+                } elseif ($authType === 'apikey' && $credentials) {
+                    $request = $request->withHeaders([$authHeader => $credentials]);
+                } elseif ($authType === 'basic') {
+                    $request = $request->withBasicAuth(...explode(':', $credentials, 2));
+                }
+
+                $response = $request->post($url, $extraParams);
+            } finally {
+                if (is_resource($fileHandle)) {
+                    fclose($fileHandle);
+                }
+            }
+
+            if ($response->successful()) {
+                return $response->json();
+            }
+
+            Log::error('RemoteDocumentProcessor: request failed', [
+                'url' => $url,
+                'status' => $response->status(),
+                'body' => substr($response->body(), 0, 500),
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('RemoteDocumentProcessor: request error', [
+                'url' => $url,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return null;
+    }
+
+    private function parseResponse(array $response): array
+    {
+        $mapping = config('services.document_processor.response_mapping', []);
+        $mode = $mapping['mode'] ?? 'fields';
+
+        $transactionsPath = $mapping['transactions_path'] ?? 'transactions';
+        $items = Arr::get($response, $transactionsPath, []);
+
+        if (! is_array($items) || empty($items)) {
+            Log::info('RemoteDocumentProcessor: no items at path', [
+                'path' => $transactionsPath,
+                'keys' => array_keys($response),
+            ]);
+
+            return [];
+        }
+
+        // Optional filter: only process items matching a condition
+        $filter = $mapping['filter'] ?? null;
+        if ($filter && isset($filter['key'], $filter['value'])) {
+            $items = array_filter($items, fn ($item) => Arr::get($item, $filter['key']) === $filter['value']);
+        }
+
+        return match ($mode) {
+            'text_block' => $this->parseTextBlocks($items, $mapping),
+            default => $this->parseFields($items, $mapping),
+        };
+    }
+
+    /**
+     * Mode: fields — each item has named keys for date, amount, etc.
+     */
+    private function parseFields(array $items, array $mapping): array
+    {
+        $dateField = $mapping['date_field'] ?? 'date';
+        $descriptionField = $mapping['description_field'] ?? 'description';
+        $amountField = $mapping['amount_field'] ?? 'amount';
+        $currencyField = $mapping['currency_field'] ?? 'currency';
+        $typeField = $mapping['type_field'] ?? 'type';
+        $partyField = $mapping['party_field'] ?? 'party';
+        $categoryField = $mapping['category_field'] ?? 'category';
+        $confidenceField = $mapping['confidence_field'] ?? 'confidence';
+
+        $suggestions = [];
+
+        foreach ($items as $tx) {
+            if (! is_array($tx)) {
+                continue;
+            }
+
+            $amount = Arr::get($tx, $amountField);
+            if ($amount === null || $amount === '') {
+                continue;
+            }
+
+            $rawAmount = (float) str_replace(',', '', (string) $amount);
+            $type = Arr::get($tx, $typeField);
+
+            if (empty($type)) {
+                $type = $rawAmount < 0 ? 'expense' : 'income';
+            }
+
+            $date = $this->normalizeDate(Arr::get($tx, $dateField));
+            if ($date === null) {
+                continue;
+            }
+
+            $suggestions[] = new TransactionSuggestion(
+                amount: abs($rawAmount),
+                currency: Arr::get($tx, $currencyField),
+                type: $type,
+                party: Arr::get($tx, $partyField),
+                category: Arr::get($tx, $categoryField),
+                description: Arr::get($tx, $descriptionField),
+                date: $date,
+                confidence: (float) (Arr::get($tx, $confidenceField) ?? 0.8),
+                documentType: 'remote',
+            );
+        }
+
+        return $suggestions;
+    }
+
+    /**
+     * Mode: text_block — each item has a text blob, split by newlines, mapped by line index.
+     *
+     * Example: content = "31 Mar, 2024\nCard charge (Starlink)\n-36.12\nEUR\n3437.35"
+     * With line_mapping: { date: 0, description: 1, amount: 2, currency: 3 }
+     */
+    private function parseTextBlocks(array $items, array $mapping): array
+    {
+        $contentField = $mapping['content_field'] ?? 'content';
+        $lineMapping = $mapping['line_mapping'] ?? [
+            'date' => 0,
+            'description' => 1,
+            'amount' => 2,
+            'currency' => 3,
+        ];
+
+        $suggestions = [];
+
+        foreach ($items as $item) {
+            $suggestion = $this->parseTextBlockItem($item, $contentField, $lineMapping);
+            if ($suggestion !== null) {
+                $suggestions[] = $suggestion;
+            }
+        }
+
+        return $suggestions;
+    }
+
+    private function parseTextBlockItem(mixed $item, string $contentField, array $lineMapping): ?TransactionSuggestion
+    {
+        $content = is_array($item) ? Arr::get($item, $contentField, '') : (string) $item;
+        $lines = array_map('trim', explode("\n", trim($content)));
+
+        $date = $this->getLine($lines, $lineMapping['date'] ?? null);
+        $amount = $this->getLine($lines, $lineMapping['amount'] ?? null);
+
+        if ($date === null || $amount === null) {
+            return null;
+        }
+
+        $normalizedDate = $this->normalizeDate($date);
+        if ($normalizedDate === null) {
+            return null;
+        }
+
+        $rawAmount = (float) str_replace(',', '', $amount);
+        if ($rawAmount == 0) {
+            return null;
+        }
+
+        if ($this->isSkippedStatus($this->getLine($lines, $lineMapping['status'] ?? null))) {
+            return null;
+        }
+
+        $description = $this->getLine($lines, $lineMapping['description'] ?? null) ?? '';
+        $currency = $this->getLine($lines, $lineMapping['currency'] ?? null);
+
+        return new TransactionSuggestion(
+            amount: abs($rawAmount),
+            currency: $currency,
+            type: $rawAmount < 0 ? 'expense' : 'income',
+            party: $this->extractPartyFromDescription($description),
+            description: $description,
+            date: $normalizedDate,
+            confidence: 0.8,
+            documentType: 'remote',
+        );
+    }
+
+    private function isSkippedStatus(?string $status): bool
+    {
+        return $status !== null && in_array(strtolower($status), ['canceled', 'cancelled', 'failed', 'reversed']);
+    }
+
+    /**
+     * Extract party from parentheses in description: "Card charge (VENDOR)" -> "VENDOR"
+     */
+    private function extractPartyFromDescription(string $description): ?string
+    {
+        if (preg_match('/\(([^)]+)\)/', $description, $partyMatch)) {
+            return $partyMatch[1];
+        }
+
+        return null;
+    }
+
+    private function getLine(array $lines, ?int $index): ?string
+    {
+        if ($index === null || ! isset($lines[$index])) {
+            return null;
+        }
+
+        $val = trim($lines[$index]);
+
+        return $val !== '' ? $val : null;
+    }
+
+    private function normalizeDate(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            return $value;
+        }
+
+        // Remove commas that confuse Carbon (e.g. "05 Apr, 2024" → "05 Apr 2024")
+        $value = str_replace(',', '', $value);
+
+        try {
+            return Carbon::parse($value)->format('Y-m-d');
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Extract all readable text from the processor response for LLM fallback.
+     */
+    private function extractRawText(array $response): string
+    {
+        $parts = [];
+
+        // Try elements (common in OCR responses)
+        foreach ($response['elements'] ?? [] as $element) {
+            $content = $element['content'] ?? $element['text'] ?? null;
+            if ($content) {
+                $parts[] = $content;
+            }
+        }
+
+        // Try raw_text field
+        if (empty($parts) && ! empty($response['raw_text'])) {
+            return $response['raw_text'];
+        }
+
+        // Try tables
+        foreach ($response['tables'] ?? [] as $table) {
+            foreach ($table['headers'] ?? [] as $h) {
+                $parts[] = $h;
+            }
+            foreach ($table['rows'] ?? [] as $row) {
+                $parts[] = implode(' | ', $row);
+            }
+        }
+
+        return implode("\n", $parts);
+    }
+
+    /**
+     * Use LLM to extract transactions from raw unstructured text.
+     *
+     * @return TransactionSuggestion[]
+     */
+    private function extractViaLlm(string $rawText): array
+    {
+        $provider = config('services.llm.provider', 'groq');
+        $model = config('services.llm.model', 'llama-3.1-8b-instant');
+
+        // Truncate to avoid token limits
+        $rawText = mb_substr($rawText, 0, 8000);
+
+        try {
+            $response = Prism::text()
+                ->using($provider, $model)
+                ->withSystemPrompt(<<<'PROMPT'
+You are a financial document parser. Given raw text extracted from a financial
+document (bank statement, receipt, invoice), extract all transactions you can find.
+
+Return ONLY a valid JSON array. No other text, no markdown fences.
+Each transaction must have these keys:
+- date: string in YYYY-MM-DD format
+- description: string describing the transaction
+- amount: number (negative for expenses/debits, positive for income/credits)
+- currency: 3-letter currency code (e.g. USD, EUR)
+
+If you cannot determine a field, use null. Skip non-transaction text (headers, footers, account info).
+PROMPT)
+                ->withPrompt("Extract transactions from this document text:\n\n" . $rawText)
+                ->usingTemperature(0)
+                ->asText();
+
+            $parsed = $this->parseLlmJson($response->text);
+
+            if (! is_array($parsed) || empty($parsed)) {
+                return [];
+            }
+
+            $suggestions = [];
+            foreach ($parsed as $tx) {
+                $amount = $tx['amount'] ?? null;
+                if ($amount === null) {
+                    continue;
+                }
+
+                $rawAmount = (float) $amount;
+                $date = $this->normalizeDate($tx['date'] ?? null);
+
+                $description = $tx['description'] ?? '';
+                $party = null;
+                if (preg_match('/\(([^)]+)\)/', $description, $match)) {
+                    $party = $match[1];
+                }
+
+                $suggestions[] = new TransactionSuggestion(
+                    amount: abs($rawAmount),
+                    currency: $tx['currency'] ?? null,
+                    type: $rawAmount < 0 ? 'expense' : 'income',
+                    party: $party,
+                    description: $description,
+                    date: $date,
+                    confidence: 0.6,
+                    documentType: 'llm_fallback',
+                );
+            }
+
+            return $suggestions;
+        } catch (\Throwable $e) {
+            Log::warning('RemoteDocumentProcessor: LLM fallback unavailable', ['error' => $e->getMessage()]);
+
+            return [];
+        }
+    }
+
+    private function parseLlmJson(string $text): ?array
+    {
+        $text = trim($text);
+
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text);
+            $text = preg_replace('/\s*```$/', '', $text);
+        }
+
+        $decoded = json_decode($text, true);
+
+        return (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) ? $decoded : null;
+    }
+}

--- a/app/Services/DuplicateDetectionService.php
+++ b/app/Services/DuplicateDetectionService.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Types\DuplicateMatch;
+use App\Types\TransactionSuggestion;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class DuplicateDetectionService
+{
+    private const DATE_RANGE_DAYS = 3;
+
+    private const AMOUNT_TOLERANCE_PERCENT = 5;
+
+    /**
+     * Check a batch of suggestions against the user's existing transactions.
+     *
+     * @param  TransactionSuggestion[]  $suggestions
+     * @return array<int, DuplicateMatch|null> Indexed same as input
+     */
+    public function checkBatch(array $suggestions, User $user): array
+    {
+        if (empty($suggestions)) {
+            return [];
+        }
+
+        $existingTransactions = $this->loadRelevantTransactions($suggestions, $user);
+        $results = [];
+
+        foreach ($suggestions as $suggestion) {
+            $results[] = $this->findMatch($suggestion, $existingTransactions);
+        }
+
+        return $results;
+    }
+
+    private function findMatch(TransactionSuggestion $suggestion, Collection $transactions): ?DuplicateMatch
+    {
+        if ($suggestion->amount === null || $suggestion->date === null) {
+            return null;
+        }
+
+        try {
+            $suggestedDate = Carbon::parse($suggestion->date);
+        } catch (\Exception) {
+            return null;
+        }
+
+        $normalizedDescription = $this->normalizeString($suggestion->description);
+
+        foreach ($transactions as $transaction) {
+            $txDate = Carbon::parse($transaction->datetime);
+            $txAmount = (float) $transaction->amount;
+            $daysDiff = abs($suggestedDate->diffInDays($txDate));
+
+            $matchType = null;
+            $matchConfidence = 0;
+
+            // Exact match: same amount + same date + similar description
+            if (
+                $txAmount == $suggestion->amount
+                && $daysDiff === 0
+                && $this->descriptionsMatch($normalizedDescription, $this->normalizeString($transaction->description))
+            ) {
+                $matchType = 'exact';
+                $matchConfidence = 1.0;
+            } elseif ($txAmount == $suggestion->amount && $daysDiff <= self::DATE_RANGE_DAYS) {
+                // Near match: same amount + date within ±3 days
+                $matchType = 'near';
+                $matchConfidence = 0.8;
+            } elseif ($daysDiff <= self::DATE_RANGE_DAYS && $this->amountsAreSimilar($suggestion->amount, $txAmount)) {
+                // Similar match: amount within ±5% + date within ±3 days
+                $matchType = 'similar';
+                $matchConfidence = 0.5;
+            }
+
+            if ($matchType !== null) {
+                return new DuplicateMatch(
+                    transactionId: $transaction->id,
+                    matchType: $matchType,
+                    confidence: $matchConfidence,
+                    transactionAmount: $txAmount,
+                    transactionDescription: $transaction->description,
+                    transactionDate: $txDate->format('Y-m-d'),
+                    transactionType: $transaction->type,
+                );
+            }
+        }
+
+        return null;
+    }
+
+    private function loadRelevantTransactions(array $suggestions, User $user): Collection
+    {
+        $dates = array_filter(array_map(fn (TransactionSuggestion $suggestion) => $suggestion->date, $suggestions));
+
+        if (empty($dates)) {
+            return collect();
+        }
+
+        $parsedDates = [];
+        foreach ($dates as $date) {
+            try {
+                $parsedDates[] = Carbon::parse($date);
+            } catch (\Exception) {
+                // skip unparseable dates
+            }
+        }
+
+        if (empty($parsedDates)) {
+            return collect();
+        }
+
+        $minDate = min($parsedDates)->copy()->subDays(self::DATE_RANGE_DAYS);
+        $maxDate = max($parsedDates)->copy()->addDays(self::DATE_RANGE_DAYS);
+
+        return $user->transactions()
+            ->whereBetween('datetime', [$minDate->toDateString(), $maxDate->toDateString()])
+            ->select(['id', 'amount', 'description', 'datetime', 'type'])
+            ->get();
+    }
+
+    private function amountsAreSimilar(float $first, float $second): bool
+    {
+        if ($first == 0 && $second == 0) {
+            return true;
+        }
+
+        if ($first == 0 || $second == 0) {
+            return false;
+        }
+
+        $percentDiff = abs($first - $second) / max(abs($first), abs($second)) * 100;
+
+        return $percentDiff <= self::AMOUNT_TOLERANCE_PERCENT;
+    }
+
+    private function descriptionsMatch(?string $first, ?string $second): bool
+    {
+        if ($first === null || $second === null) {
+            return $first === $second;
+        }
+
+        if ($first === $second) {
+            return true;
+        }
+
+        $maxLen = max(strlen($first), strlen($second));
+        if ($maxLen === 0) {
+            return true;
+        }
+
+        $threshold = (int) ($maxLen * 0.2);
+
+        return levenshtein($first, $second) <= $threshold;
+    }
+
+    private function normalizeString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return strtolower(trim(preg_replace('/\s+/', ' ', $value)));
+    }
+}

--- a/app/Services/SuggestionEnricher.php
+++ b/app/Services/SuggestionEnricher.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Types\TransactionSuggestion;
+use Illuminate\Support\Facades\Log;
+use Prism\Prism\Facades\Prism;
+
+class SuggestionEnricher
+{
+    /**
+     * Enrich raw transaction suggestions by mapping them to the user's
+     * existing wallets, categories, and parties using an LLM.
+     *
+     * @param  TransactionSuggestion[]  $suggestions
+     * @return TransactionSuggestion[]
+     */
+    public function enrich(array $suggestions, User $user): array
+    {
+        if (empty($suggestions)) {
+            return [];
+        }
+
+        $wallets = $user->wallets()->select('name', 'currency')->get()->toArray();
+        $categories = $user->categories()->select('name', 'type')->get()->toArray();
+        $parties = $user->parties()->select('name')->get()->toArray();
+
+        // If user has no existing entities, skip LLM call — nothing to match against
+        // but still try to classify type and clean descriptions
+        $suggestionsData = array_map(fn (TransactionSuggestion $suggestion) => [
+            'amount' => $suggestion->amount,
+            'currency' => $suggestion->currency,
+            'type' => $suggestion->type,
+            'party' => $suggestion->party,
+            'wallet' => $suggestion->wallet,
+            'category' => $suggestion->category,
+            'description' => $suggestion->description,
+            'date' => $suggestion->date,
+        ], $suggestions);
+
+        $prompt = $this->buildPrompt($suggestionsData, $wallets, $categories, $parties);
+
+        try {
+            $response = Prism::text()
+                ->using(
+                    config('services.llm.provider', 'groq'),
+                    config('services.llm.model', 'llama-3.1-8b-instant'),
+                )
+                ->withSystemPrompt($this->systemPrompt())
+                ->withPrompt($prompt)
+                ->usingTemperature(0)
+                ->asText();
+
+            $enriched = $this->parseResponse($response->text);
+
+            if (is_array($enriched) && count($enriched) === count($suggestions)) {
+                return $this->mergeEnrichments($suggestions, $enriched);
+            }
+
+            Log::warning('SuggestionEnricher: LLM response count mismatch', [
+                'expected' => count($suggestions),
+                'got' => is_array($enriched) ? count($enriched) : 'invalid',
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('SuggestionEnricher: LLM unavailable, skipping enrichment', ['error' => $e->getMessage()]);
+        }
+
+        return $suggestions;
+    }
+
+    private function systemPrompt(): string
+    {
+        return <<<'PROMPT'
+You are a financial transaction classifier.
+
+CRITICAL RULES:
+- wallet: MUST match by currency. A EUR transaction can ONLY go to a EUR wallet.
+  A USD transaction can ONLY go to a USD wallet. NEVER assign a mismatched currency.
+  Use null if no wallet has the right currency.
+- category: Use an existing category if the description matches. Use null if nothing fits.
+- party: Use an existing party if the merchant/sender matches. Use null if nothing fits.
+- type: "income" for money received, "expense" for money spent.
+- description: Clean up raw text (e.g. "AMZN MKTP US*ABC123" → "Amazon Marketplace").
+
+OUTPUT FORMAT:
+- Respond with ONLY a valid JSON array. No other text, no markdown code fences.
+- Each element must have exactly these keys: wallet, category, party, type, description.
+- Use null (not empty string) when no match is found.
+PROMPT;
+    }
+
+    private function buildPrompt(array $suggestions, array $wallets, array $categories, array $parties): string
+    {
+        $parts = [];
+
+        $parts[] = '=== AVAILABLE WALLETS (use ONLY these, matched by currency) ===';
+        if (! empty($wallets)) {
+            foreach ($wallets as $wallet) {
+                $parts[] = "- \"{$wallet['name']}\" (currency: {$wallet['currency']})";
+            }
+        } else {
+            $parts[] = 'None — set wallet to null for all transactions.';
+        }
+
+        $parts[] = "\n=== AVAILABLE CATEGORIES ===";
+        if (! empty($categories)) {
+            foreach ($categories as $category) {
+                $parts[] = "- \"{$category['name']}\" (type: {$category['type']})";
+            }
+        } else {
+            $parts[] = 'None — set category to null.';
+        }
+
+        $parts[] = "\n=== AVAILABLE PARTIES ===";
+        if (! empty($parties)) {
+            foreach ($parties as $party) {
+                $parts[] = "- \"{$party['name']}\"";
+            }
+        } else {
+            $parts[] = 'None — set party to null.';
+        }
+
+        $count = count($suggestions);
+        $parts[] = "\n=== TRANSACTIONS TO CLASSIFY ({$count}) ===";
+        $parts[] = json_encode($suggestions);
+
+        $parts[] = "\nReturn exactly {$count} JSON objects.";
+
+        return implode("\n\n", $parts);
+    }
+
+    private function parseResponse(string $text): ?array
+    {
+        $text = trim($text);
+
+        // Strip markdown code fences if present
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text);
+            $text = preg_replace('/\s*```$/', '', $text);
+        }
+
+        $decoded = json_decode($text, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_array($decoded)) {
+            Log::warning('SuggestionEnricher: Failed to parse LLM JSON', [
+                'error' => json_last_error_msg(),
+                'response' => substr($text, 0, 500),
+            ]);
+
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  TransactionSuggestion[]  $suggestions
+     * @return TransactionSuggestion[]
+     */
+    private function mergeEnrichments(array $suggestions, array $enrichments): array
+    {
+        $result = [];
+
+        foreach ($suggestions as $i => $suggestion) {
+            $enrichment = $enrichments[$i] ?? [];
+
+            $result[] = new TransactionSuggestion(
+                amount: $suggestion->amount,
+                currency: $suggestion->currency,
+                type: $enrichment['type'] ?? $suggestion->type,
+                party: $enrichment['party'] ?? $suggestion->party,
+                wallet: $enrichment['wallet'] ?? $suggestion->wallet,
+                category: $enrichment['category'] ?? $suggestion->category,
+                description: $enrichment['description'] ?? $suggestion->description,
+                date: $suggestion->date,
+                confidence: $suggestion->confidence,
+                documentType: $suggestion->documentType,
+            );
+        }
+
+        return $result;
+    }
+}

--- a/app/Types/DuplicateMatch.php
+++ b/app/Types/DuplicateMatch.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Types;
+
+readonly class DuplicateMatch
+{
+    public function __construct(
+        public int $transactionId,
+        public string $matchType,
+        public float $confidence,
+        public ?float $transactionAmount = null,
+        public ?string $transactionDescription = null,
+        public ?string $transactionDate = null,
+        public ?string $transactionType = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'transaction_id' => $this->transactionId,
+            'match_type' => $this->matchType,
+            'confidence' => $this->confidence,
+            'transaction_amount' => $this->transactionAmount,
+            'transaction_description' => $this->transactionDescription,
+            'transaction_date' => $this->transactionDate,
+            'transaction_type' => $this->transactionType,
+        ];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            transactionId: (int) $data['transaction_id'],
+            matchType: $data['match_type'],
+            confidence: (float) $data['confidence'],
+            transactionAmount: $data['transaction_amount'] ?? null,
+            transactionDescription: $data['transaction_description'] ?? null,
+            transactionDate: $data['transaction_date'] ?? null,
+            transactionType: $data['transaction_type'] ?? null,
+        );
+    }
+}

--- a/app/Types/TransactionSuggestion.php
+++ b/app/Types/TransactionSuggestion.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Types;
+
+readonly class TransactionSuggestion
+{
+    /** @SuppressWarnings(PHPMD.ExcessiveParameterList) */
+    public function __construct(
+        public ?float $amount = null,
+        public ?string $currency = null,
+        public ?string $type = null,
+        public ?string $party = null,
+        public ?string $wallet = null,
+        public ?string $category = null,
+        public ?string $description = null,
+        public ?string $date = null,
+        public float $confidence = 1.0,
+        public ?string $documentType = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+            'type' => $this->type,
+            'party' => $this->party,
+            'wallet' => $this->wallet,
+            'category' => $this->category,
+            'description' => $this->description,
+            'date' => $this->date,
+            'confidence' => $this->confidence,
+            'document_type' => $this->documentType,
+        ];
+    }
+
+    /**
+     * Convert to the positional array format used by FileImportService::importTransaction().
+     */
+    public function toImportArray(): array
+    {
+        return [
+            $this->amount ?? '',
+            $this->currency ?? '',
+            $this->type ?? '',
+            $this->party ?? '',
+            $this->wallet ?? '',
+            $this->category ?? '',
+            $this->description ?? '',
+            $this->date ?? '',
+        ];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            amount: isset($data['amount']) ? (float) $data['amount'] : null,
+            currency: $data['currency'] ?? null,
+            type: $data['type'] ?? null,
+            party: $data['party'] ?? null,
+            wallet: $data['wallet'] ?? null,
+            category: $data['category'] ?? null,
+            description: $data['description'] ?? null,
+            date: $data['date'] ?? null,
+            confidence: (float) ($data['confidence'] ?? 1.0),
+            documentType: $data['document_type'] ?? null,
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/framework": "^11.45.1",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.8",
+        "prism-php/prism": "^0.100.1",
         "rlanvin/php-rrule": "^2.6",
         "smartpings/php-sdk": "dev-main",
         "whilesmart/eloquent-model-configuration": "^1.0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4401762fee0a682f1d207c388a6663c",
+    "content-hash": "cf09dd5b73f33474a876ecf0670b53bf",
     "packages": [
         {
             "name": "beste/clock",
@@ -4497,6 +4497,85 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "prism-php/prism",
+            "version": "v0.100.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/prism-php/prism.git",
+                "reference": "5d6cc65b80b19cf3f22744703ac0c727b68cdca8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/prism-php/prism/zipball/5d6cc65b80b19cf3f22744703ac0c727b68cdca8",
+                "reference": "5d6cc65b80b19cf3f22744703ac0c727b68cdca8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "laravel/framework": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.8.4",
+                "laravel/mcp": "^0.6.0",
+                "laravel/pint": "^1.14",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9|^10|^11",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-arch": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/extension-installer": "^1.3",
+                "phpstan/phpdoc-parser": "^2.0",
+                "phpstan/phpstan": "2.1.34",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "projektgopher/whisky": "^0.7.0",
+                "rector/rector": "2.3.3",
+                "spatie/laravel-ray": "^1.39",
+                "symplify/rule-doc-generator-contracts": "^11.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PrismServer": "Prism\\Prism\\Facades\\PrismServer"
+                    },
+                    "providers": [
+                        "Prism\\Prism\\PrismServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Prism\\Prism\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "TJ Miller",
+                    "email": "hello@echolabs.dev"
+                }
+            ],
+            "description": "A powerful Laravel package for integrating Large Language Models (LLMs) into your applications.",
+            "support": {
+                "issues": "https://github.com/prism-php/prism/issues",
+                "source": "https://github.com/prism-php/prism/tree/v0.100.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sixlive",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-20T20:37:17+00:00"
         },
         {
             "name": "psr/cache",

--- a/config/services.php
+++ b/config/services.php
@@ -41,4 +41,71 @@ return [
         'url' => env('SMARTQL_URL', 'http://smartql:8000'),
     ],
 
+    'llm' => [
+        'provider' => env('LLM_PROVIDER', 'groq'),
+        'model' => env('LLM_MODEL', 'llama-3.1-8b-instant'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remote Document Processor
+    |--------------------------------------------------------------------------
+    |
+    | Configure a remote service to extract transactions from documents.
+    | Any service that accepts a file upload and returns JSON with a
+    | "transactions" array works. Use response_mapping to adapt
+    | services that use different field names.
+    |
+    | Expected response: { "transactions": [{ "date", "description", "amount", "currency" }] }
+    |
+    */
+    'document_processor' => [
+        'url' => env('DOCUMENT_PROCESSOR_URL'),
+        'timeout' => env('DOCUMENT_PROCESSOR_TIMEOUT', 120),
+        'auth_type' => env('DOCUMENT_PROCESSOR_AUTH_TYPE', 'none'),
+        'auth_credentials' => env('DOCUMENT_PROCESSOR_AUTH_CREDENTIALS'),
+        'auth_header' => env('DOCUMENT_PROCESSOR_AUTH_HEADER', 'X-API-Key'),
+        'file_field' => env('DOCUMENT_PROCESSOR_FILE_FIELD', 'file'),
+        'extra_params' => [],
+        /*
+        | Response mapping — tells the processor how to find transactions in the response.
+        |
+        | Two modes:
+        |   "fields" (default) — each item in the array has named keys:
+        |       { "date": "...", "amount": -50, "description": "..." }
+        |
+        |   "text_block" — each item has a text blob split by newlines:
+        |       { "content": "31 Mar, 2024\nCard charge\n-36.12\nEUR" }
+        |       Use line_mapping to say which line index maps to which field.
+        |
+        | Example for a standard API:
+        |   'transactions_path' => 'transactions',
+        |   'mode' => 'fields',
+        |
+        | Example for PageMind (elements as text blocks):
+        |   'transactions_path' => 'elements',
+        |   'mode' => 'text_block',
+        |   'content_field' => 'content',
+        |   'filter' => ['key' => 'subtype', 'value' => 'paragraph'],
+        |   'line_mapping' => ['date' => 0, 'description' => 1, 'amount' => 2, 'currency' => 3, 'status' => 4],
+        */
+        'response_mapping' => [
+            'transactions_path' => env('DOCUMENT_PROCESSOR_TRANSACTIONS_PATH', 'transactions'),
+            'mode' => env('DOCUMENT_PROCESSOR_MODE', 'fields'),
+            'content_field' => 'content',
+            'filter' => env('DOCUMENT_PROCESSOR_FILTER_KEY')
+                ? ['key' => env('DOCUMENT_PROCESSOR_FILTER_KEY'), 'value' => env('DOCUMENT_PROCESSOR_FILTER_VALUE')]
+                : null,
+            'line_mapping' => [
+                'date' => (int) env('DOCUMENT_PROCESSOR_LINE_DATE', 0),
+                'description' => (int) env('DOCUMENT_PROCESSOR_LINE_DESCRIPTION', 1),
+                'amount' => (int) env('DOCUMENT_PROCESSOR_LINE_AMOUNT', 2),
+                'currency' => (int) env('DOCUMENT_PROCESSOR_LINE_CURRENCY', 3),
+                'status' => env('DOCUMENT_PROCESSOR_LINE_STATUS') !== null
+                    ? (int) env('DOCUMENT_PROCESSOR_LINE_STATUS')
+                    : null,
+            ],
+        ],
+    ],
+
 ];

--- a/database/migrations/2026_04_03_000001_create_import_sessions_table.php
+++ b/database/migrations/2026_04_03_000001_create_import_sessions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('import_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('file_name');
+            $table->string('file_type');
+            $table->string('document_type')->nullable();
+            $table->string('processor');
+            $table->string('status')->default('analyzing');
+            $table->json('suggestions');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('import_sessions');
+    }
+};

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -1153,6 +1153,134 @@
                 }
             }
         },
+        "/import/analyze": {
+            "post": {
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Analyze a document and return transaction suggestions",
+                "operationId": "dbd8a0e3c1510b8dcaa9f3dbab7683f0",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    },
+                                    "document_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "bank_statement",
+                                            "receipt",
+                                            "invoice",
+                                            "pay_stub",
+                                            "utility_bill"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Suggestions returned"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                }
+            }
+        },
+        "/import/confirm": {
+            "post": {
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Confirm and create transactions from reviewed suggestions",
+                "operationId": "1fdb80050f2d675d2bc4bd942a6958c3",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "session_id": {
+                                        "type": "integer"
+                                    },
+                                    "accepted": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transactions created"
+                    },
+                    "404": {
+                        "description": "Session not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                }
+            }
+        },
+        "/import/sessions": {
+            "get": {
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Get all import sessions",
+                "operationId": "4b1fd8aaf51c6886128c91724557bb6a",
+                "responses": {
+                    "200": {
+                        "description": "Sessions list"
+                    }
+                }
+            }
+        },
+        "/import/sessions/{id}": {
+            "get": {
+                "tags": [
+                    "Import"
+                ],
+                "summary": "Get a specific import session",
+                "operationId": "01f697986c3877e4c2d6b72b0970aaf6",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Session details"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                }
+            }
+        },
         "/notifications": {
             "get": {
                 "tags": [

--- a/routes/api.php
+++ b/routes/api.php
@@ -51,7 +51,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['auth:sanctum']], function () {
     Route::post('categories/seed-defaults', [CategoryController::class, 'seedDefaults']);
     Route::apiResource('categories', CategoryController::class);
 
-    // Import routes
+    // Advanced import routes (analyze → review → confirm)
+    Route::post('import/analyze', [ImportController::class, 'analyze']);
+    Route::post('import/confirm', [ImportController::class, 'confirm']);
+    Route::get('import/sessions', [ImportController::class, 'getSessions']);
+    Route::get('import/sessions/{id}', [ImportController::class, 'getSession']);
+
+    // Import routes (legacy CSV auto-import)
     Route::post('import', [ImportController::class, 'import']);
     Route::get('imports', [ImportController::class, 'getImports']);
     Route::get('imports/{id}/failed', [ImportController::class, 'getFailedImports']);

--- a/tests/Feature/AdvancedImportTest.php
+++ b/tests/Feature/AdvancedImportTest.php
@@ -1,0 +1,567 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AdvancedImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_analyze_with_csv_creates_session_with_analyzing_status(): void
+    {
+        Storage::fake('local');
+        Queue::fake();
+
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,Store,Wallet,Food,Lunch,2025-01-01\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $response = $this->actingAs($this->user)->post('/api/v1/import/analyze', [
+            'file' => $file,
+        ]);
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertEquals('analyzing', $data['status']);
+        $this->assertEquals('test.csv', $data['file_name']);
+        $this->assertEquals('csv', $data['file_type']);
+    }
+
+    public function test_analyze_rejects_unsupported_file_types(): void
+    {
+        Storage::fake('local');
+
+        $file = UploadedFile::fake()->create('document.txt', 100, 'text/plain');
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/analyze', [
+            'file' => $file,
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_analyze_requires_authentication(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n";
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $response = $this->postJson('/api/v1/import/analyze', [
+            'file' => $file,
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_confirm_creates_transactions_from_accepted_suggestions(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 100.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Lunch',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+                [
+                    'amount' => 200.00,
+                    'currency' => 'EUR',
+                    'type' => 'income',
+                    'party' => 'Employer',
+                    'wallet' => 'Savings',
+                    'category' => 'Salary',
+                    'description' => 'Monthly pay',
+                    'date' => '2025-01-02',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 0],
+                ['index' => 1],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertEquals(2, $data['created_count']);
+        $this->assertEmpty($data['errors']);
+
+        // Verify the session status was updated
+        $session->refresh();
+        $this->assertEquals('confirmed', $session->status);
+
+        // Verify transactions were created
+        $this->assertEquals(2, $this->user->transactions()->count());
+    }
+
+    public function test_confirm_rejects_already_confirmed_sessions(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'confirmed',
+            'suggestions' => [
+                [
+                    'amount' => 100.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Lunch',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 0],
+            ],
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_confirm_returns_404_for_other_users_session(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $session = $otherUser->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 100.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Lunch',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 0],
+            ],
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_get_sessions_returns_user_sessions(): void
+    {
+        $this->user->importSessions()->create([
+            'file_name' => 'first.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [],
+        ]);
+
+        $this->user->importSessions()->create([
+            'file_name' => 'second.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'confirmed',
+            'suggestions' => [],
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/import/sessions');
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertCount(2, $data);
+    }
+
+    public function test_get_sessions_does_not_return_other_users_sessions(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $otherUser->importSessions()->create([
+            'file_name' => 'other.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [],
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/import/sessions');
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertCount(0, $data);
+    }
+
+    public function test_get_session_returns_specific_session(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => 'bank_statement',
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [['amount' => 100]],
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/v1/import/sessions/{$session->id}");
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertEquals('test.csv', $data['file_name']);
+        $this->assertEquals('bank_statement', $data['document_type']);
+        $this->assertEquals('ready', $data['status']);
+    }
+
+    public function test_get_session_returns_404_for_other_users_session(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $session = $otherUser->importSessions()->create([
+            'file_name' => 'secret.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [],
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/v1/import/sessions/{$session->id}");
+
+        $response->assertStatus(404);
+    }
+
+    public function test_get_session_returns_404_for_nonexistent_session(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/v1/import/sessions/99999');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_confirm_with_user_edits_overrides_suggestion_fields(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 100.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Lunch',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                [
+                    'index' => 0,
+                    'amount' => 150.00,
+                    'description' => 'Edited description',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertEquals(1, $data['created_count']);
+
+        // Verify the transaction was created with the edited amount
+        $transaction = $this->user->transactions()->first();
+        $this->assertEquals(150.00, $transaction->amount);
+        $this->assertEquals('Edited description', $transaction->description);
+    }
+
+    public function test_confirm_with_invalid_suggestion_index_returns_error(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 100.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Lunch',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 99],
+            ],
+        ]);
+
+        // Should still return 206 because errors occurred but session is confirmed
+        $response->assertStatus(206);
+
+        $data = $response->json('data');
+        $this->assertEquals(0, $data['created_count']);
+        $this->assertNotEmpty($data['errors']);
+    }
+
+    public function test_confirm_with_date_override(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 75.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Groceries',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                [
+                    'index' => 0,
+                    'date' => '2025-06-15',
+                    'amount' => 80.00,
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $transaction = $this->user->transactions()->first();
+        $this->assertNotNull($transaction);
+        $this->assertEquals(80.00, $transaction->amount);
+    }
+
+    public function test_analyze_with_document_type_parameter(): void
+    {
+        Storage::fake('local');
+        Queue::fake();
+
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,Store,Wallet,Food,Lunch,2025-01-01\n";
+
+        $file = UploadedFile::fake()->createWithContent('statement.csv', $csv);
+
+        $response = $this->actingAs($this->user)->post('/api/v1/import/analyze', [
+            'file' => $file,
+            'document_type' => 'bank_statement',
+        ]);
+
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertEquals('bank_statement', $data['document_type']);
+        $this->assertEquals('analyzing', $data['status']);
+    }
+
+    public function test_analyze_rejects_invalid_document_type(): void
+    {
+        Storage::fake('local');
+
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,Store,Wallet,Food,Lunch,2025-01-01\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/analyze', [
+            'file' => $file,
+            'document_type' => 'invalid_type',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_sessions_are_scoped_to_authenticated_user(): void
+    {
+        $otherUser = User::factory()->create();
+
+        // Create sessions for both users
+        $this->user->importSessions()->create([
+            'file_name' => 'my-file.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [],
+        ]);
+
+        $otherUser->importSessions()->create([
+            'file_name' => 'other-file.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [],
+        ]);
+
+        // User should only see their own session
+        $response = $this->actingAs($this->user)->getJson('/api/v1/import/sessions');
+        $response->assertStatus(200);
+
+        $data = $response->json('data');
+        $this->assertCount(1, $data);
+        $this->assertEquals('my-file.csv', $data[0]['file_name']);
+    }
+
+    public function test_confirm_requires_accepted_array(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_confirm_requires_session_id(): void
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'accepted' => [['index' => 0]],
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_confirm_with_type_override(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 100.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'Store',
+                    'wallet' => 'Checking',
+                    'category' => 'Food',
+                    'description' => 'Refund',
+                    'date' => '2025-01-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                [
+                    'index' => 0,
+                    'type' => 'income',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $transaction = $this->user->transactions()->first();
+        $this->assertNotNull($transaction);
+        $this->assertEquals('income', $transaction->type);
+    }
+}

--- a/tests/Feature/ImportTest.php
+++ b/tests/Feature/ImportTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\User;
+use App\Services\FileImportService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -47,7 +48,7 @@ class ImportTest extends TestCase
         // Create a fake CSV file
         $csvFile = UploadedFile::fake()->createWithContent(
             'test.csv',
-            $content ?? "amount,currency,type,party,wallet,category,description,date\n".
+            $content ?: "amount,currency,type,party,wallet,category,description,date\n".
         "100,USD,expense,John Doe,Wallet1,Food,Lunch,2023-01-01\n".
         '200,USD,income,Jane Doe,Wallet2,Salary,Monthly Salary,2023-01-02'
         );
@@ -59,7 +60,16 @@ class ImportTest extends TestCase
 
         $response->assertStatus(200);
 
-        return $response->json('data');
+        $data = $response->json('data');
+
+        // Manually run the import job since dispatchAfterResponse doesn't execute in tests
+        $fileImport = $this->user->fileImports()->find($data['id']);
+        if ($fileImport) {
+            $path = Storage::disk('local')->path($fileImport->file_path);
+            app(FileImportService::class)->processImports($path, $fileImport);
+        }
+
+        return $data;
     }
 
     public function test_api_user_can_get_scheduled_imports()

--- a/tests/Feature/InsightsServiceTest.php
+++ b/tests/Feature/InsightsServiceTest.php
@@ -26,6 +26,15 @@ class InsightsServiceTest extends TestCase
         $notificationService = new NotificationService(null);
         $this->service = new InsightsService($notificationService);
         Mail::fake();
+
+        // Disable insights for any pre-existing users to isolate test counts
+        foreach (User::all() as $existingUser) {
+            $existingUser->setConfigValue(
+                InsightsService::CONFIG_KEY,
+                InsightsService::DISABLED_VALUE,
+                ConfigValueType::String
+            );
+        }
     }
 
     public function test_sends_weekly_insights_to_opted_in_users()

--- a/tests/Unit/Jobs/AnalyzeImportJobTest.php
+++ b/tests/Unit/Jobs/AnalyzeImportJobTest.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Contracts\DocumentProcessor;
+use App\Jobs\AnalyzeImportJob;
+use App\Models\User;
+use App\Services\DocumentProcessorManager;
+use App\Services\DuplicateDetectionService;
+use App\Services\SuggestionEnricher;
+use App\Types\TransactionSuggestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AnalyzeImportJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_job_processes_file_and_updates_session_to_ready(): void
+    {
+        Storage::fake('local');
+
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,Store,Wallet,Food,Lunch,2025-01-01\n";
+
+        $storedPath = 'import-analyze/test.csv';
+        Storage::put($storedPath, $csv);
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'analyzing',
+            'suggestions' => [],
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 100.00,
+                currency: 'USD',
+                type: 'expense',
+                party: 'Store',
+                wallet: 'Wallet',
+                category: 'Food',
+                description: 'Lunch',
+                date: '2025-01-01',
+                confidence: 1.0,
+                documentType: 'csv',
+            ),
+        ];
+
+        $mockProcessor = $this->createMock(DocumentProcessor::class);
+        $mockProcessor->method('process')->willReturn($suggestions);
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $processorManager->method('getProcessor')->willReturn($mockProcessor);
+
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $enricher->method('enrich')->willReturn($suggestions);
+
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+        $duplicateService->method('checkBatch')->willReturn([null]);
+
+        $job = new AnalyzeImportJob(
+            $session->id,
+            $storedPath,
+            'test.csv',
+            'text/csv',
+            'csv',
+        );
+
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        $session->refresh();
+        $this->assertEquals('ready', $session->status);
+        $this->assertCount(1, $session->suggestions);
+        $this->assertEquals(100.00, $session->suggestions[0]['amount']);
+        $this->assertEquals(1, $session->metadata['total_suggestions']);
+    }
+
+    public function test_job_updates_session_to_failed_when_file_not_found(): void
+    {
+        Storage::fake('local');
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'missing.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'analyzing',
+            'suggestions' => [],
+        ]);
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+
+        $job = new AnalyzeImportJob(
+            $session->id,
+            'import-analyze/nonexistent.csv',
+            'missing.csv',
+            'text/csv',
+            'csv',
+        );
+
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        $session->refresh();
+        $this->assertEquals('failed', $session->status);
+        $this->assertArrayHasKey('error', $session->metadata);
+        $this->assertStringContainsString('not found', $session->metadata['error']);
+    }
+
+    public function test_job_updates_session_to_failed_when_no_transactions_extracted(): void
+    {
+        Storage::fake('local');
+
+        $storedPath = 'import-analyze/empty.csv';
+        Storage::put($storedPath, "amount,currency,type\n");
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'empty.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'analyzing',
+            'suggestions' => [],
+        ]);
+
+        $mockProcessor = $this->createMock(DocumentProcessor::class);
+        $mockProcessor->method('process')->willReturn([]);
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $processorManager->method('getProcessor')->willReturn($mockProcessor);
+
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+
+        $job = new AnalyzeImportJob(
+            $session->id,
+            $storedPath,
+            'empty.csv',
+            'text/csv',
+            'csv',
+        );
+
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        $session->refresh();
+        $this->assertEquals('failed', $session->status);
+        $this->assertStringContainsString('No transactions', $session->metadata['error']);
+    }
+
+    public function test_job_goes_through_extracting_enriching_checking_stages(): void
+    {
+        Storage::fake('local');
+
+        $storedPath = 'import-analyze/stages.csv';
+        Storage::put($storedPath, "amount,currency,type,party,wallet,category,description,date\n50,USD,expense,X,W,C,D,2025-01-01\n");
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'stages.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'analyzing',
+            'suggestions' => [],
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 50.00,
+                currency: 'USD',
+                type: 'expense',
+                date: '2025-01-01',
+            ),
+        ];
+
+        $statusLog = [];
+
+        $mockProcessor = $this->createMock(DocumentProcessor::class);
+        $mockProcessor->method('process')->willReturn($suggestions);
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $processorManager->method('getProcessor')->willReturn($mockProcessor);
+
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $enricher->method('enrich')->willReturn($suggestions);
+
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+        $duplicateService->method('checkBatch')->willReturn([null]);
+
+        $job = new AnalyzeImportJob(
+            $session->id,
+            $storedPath,
+            'stages.csv',
+            'text/csv',
+            'csv',
+        );
+
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        // Final state should be 'ready' after going through all stages
+        $session->refresh();
+        $this->assertEquals('ready', $session->status);
+    }
+
+    public function test_job_handles_exception_and_sets_failed_status(): void
+    {
+        Storage::fake('local');
+
+        $storedPath = 'import-analyze/error.csv';
+        Storage::put($storedPath, "data\n");
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'error.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'analyzing',
+            'suggestions' => [],
+        ]);
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $processorManager->method('getProcessor')
+            ->willThrowException(new \RuntimeException('Processor error'));
+
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+
+        $job = new AnalyzeImportJob(
+            $session->id,
+            $storedPath,
+            'error.csv',
+            'text/csv',
+            'csv',
+        );
+
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        $session->refresh();
+        $this->assertEquals('failed', $session->status);
+        $this->assertStringContainsString('Processor error', $session->metadata['error']);
+    }
+
+    public function test_job_cleans_up_stored_file(): void
+    {
+        Storage::fake('local');
+
+        $storedPath = 'import-analyze/cleanup.csv';
+        Storage::put($storedPath, "amount,currency,type,party,wallet,category,description,date\n50,USD,expense,X,W,C,D,2025-01-01\n");
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'cleanup.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'analyzing',
+            'suggestions' => [],
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 50.00,
+                currency: 'USD',
+                type: 'expense',
+                date: '2025-01-01',
+            ),
+        ];
+
+        $mockProcessor = $this->createMock(DocumentProcessor::class);
+        $mockProcessor->method('process')->willReturn($suggestions);
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $processorManager->method('getProcessor')->willReturn($mockProcessor);
+
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $enricher->method('enrich')->willReturn($suggestions);
+
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+        $duplicateService->method('checkBatch')->willReturn([null]);
+
+        $job = new AnalyzeImportJob(
+            $session->id,
+            $storedPath,
+            'cleanup.csv',
+            'text/csv',
+            'csv',
+        );
+
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        Storage::assertMissing($storedPath);
+    }
+
+    public function test_job_handles_nonexistent_session(): void
+    {
+        Storage::fake('local');
+
+        $storedPath = 'import-analyze/orphan.csv';
+        Storage::put($storedPath, "data\n");
+
+        $processorManager = $this->createMock(DocumentProcessorManager::class);
+        $enricher = $this->createMock(SuggestionEnricher::class);
+        $duplicateService = $this->createMock(DuplicateDetectionService::class);
+
+        $job = new AnalyzeImportJob(
+            99999,
+            $storedPath,
+            'orphan.csv',
+            'text/csv',
+            'csv',
+        );
+
+        // Should not throw, just log and clean up
+        $job->handle($processorManager, $enricher, $duplicateService);
+
+        Storage::assertMissing($storedPath);
+    }
+}

--- a/tests/Unit/Services/DocumentProcessorManagerTest.php
+++ b/tests/Unit/Services/DocumentProcessorManagerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Contracts\DocumentProcessor;
+use App\Services\DocumentProcessorManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DocumentProcessorManagerTest extends TestCase
+{
+    private DocumentProcessorManager $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->manager = new DocumentProcessorManager();
+    }
+
+    public function test_can_handle_returns_true_for_supported_types(): void
+    {
+        $processor = $this->createMockProcessor('text/csv', 'csv');
+        $this->manager->register($processor);
+
+        $this->assertTrue($this->manager->canHandle('text/csv', 'csv'));
+    }
+
+    public function test_can_handle_returns_false_for_unsupported_types(): void
+    {
+        $processor = $this->createMockProcessor('text/csv', 'csv');
+        $this->manager->register($processor);
+
+        $this->assertFalse($this->manager->canHandle('application/xml', 'xml'));
+    }
+
+    public function test_can_handle_returns_false_when_no_processors_registered(): void
+    {
+        $this->assertFalse($this->manager->canHandle('text/csv', 'csv'));
+    }
+
+    public function test_get_processor_returns_correct_processor(): void
+    {
+        $csvProcessor = $this->createMockProcessor('text/csv', 'csv');
+        $pdfProcessor = $this->createMockProcessor('application/pdf', 'pdf');
+
+        $this->manager->register($csvProcessor);
+        $this->manager->register($pdfProcessor);
+
+        $this->assertSame($csvProcessor, $this->manager->getProcessor('text/csv', 'csv'));
+        $this->assertSame($pdfProcessor, $this->manager->getProcessor('application/pdf', 'pdf'));
+    }
+
+    public function test_get_processor_throws_runtime_exception_for_unsupported_types(): void
+    {
+        $processor = $this->createMockProcessor('text/csv', 'csv');
+        $this->manager->register($processor);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No document processor available for type: application/xml (xml)');
+
+        $this->manager->getProcessor('application/xml', 'xml');
+    }
+
+    public function test_get_processor_throws_when_no_processors_registered(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->manager->getProcessor('text/csv', 'csv');
+    }
+
+    public function test_multiple_processors_first_match_wins(): void
+    {
+        $firstProcessor = $this->createMockProcessor('text/csv', 'csv');
+        $secondProcessor = $this->createMockProcessor('text/csv', 'csv');
+
+        $this->manager->register($firstProcessor);
+        $this->manager->register($secondProcessor);
+
+        $this->assertSame($firstProcessor, $this->manager->getProcessor('text/csv', 'csv'));
+    }
+
+    private function createMockProcessor(string $supportedMime, string $supportedExt): DocumentProcessor
+    {
+        $processor = $this->createMock(DocumentProcessor::class);
+
+        $processor->method('supports')
+            ->willReturnCallback(function (string $mimeType, string $extension) use ($supportedMime, $supportedExt) {
+                return $mimeType === $supportedMime || $extension === $supportedExt;
+            });
+
+        return $processor;
+    }
+}

--- a/tests/Unit/Services/DocumentProcessors/CsvProcessorTest.php
+++ b/tests/Unit/Services/DocumentProcessors/CsvProcessorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Unit\Services\DocumentProcessors;
+
+use App\Models\User;
+use App\Services\DocumentProcessors\CsvProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class CsvProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CsvProcessor $processor;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->processor = app(CsvProcessor::class);
+        $this->user = User::factory()->create();
+    }
+
+    public function test_processing_valid_csv_with_transactions(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,John Doe,Checking,Food,Lunch,2025-01-01\n"
+            . "200,EUR,income,Employer,Savings,Salary,Monthly pay,2025-01-02\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(2, $suggestions);
+
+        $this->assertEquals(100.0, $suggestions[0]->amount);
+        $this->assertEquals('USD', $suggestions[0]->currency);
+        $this->assertEquals('expense', $suggestions[0]->type);
+        $this->assertEquals('John Doe', $suggestions[0]->party);
+        $this->assertEquals('Checking', $suggestions[0]->wallet);
+        $this->assertEquals('Food', $suggestions[0]->category);
+        $this->assertEquals('Lunch', $suggestions[0]->description);
+        $this->assertEquals('2025-01-01', $suggestions[0]->date);
+        $this->assertEquals(1.0, $suggestions[0]->confidence);
+        $this->assertEquals('csv', $suggestions[0]->documentType);
+
+        $this->assertEquals(200.0, $suggestions[1]->amount);
+        $this->assertEquals('EUR', $suggestions[1]->currency);
+        $this->assertEquals('income', $suggestions[1]->type);
+        $this->assertEquals('Employer', $suggestions[1]->party);
+    }
+
+    public function test_skips_header_row(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "50,USD,expense,Store,Wallet,Food,Snacks,2025-03-01\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $suggestions);
+        $this->assertEquals(50.0, $suggestions[0]->amount);
+    }
+
+    public function test_invalid_dates_get_low_confidence(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,Store,Wallet,Food,Lunch,01/15/2025\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $suggestions);
+        $this->assertEquals(0.3, $suggestions[0]->confidence);
+        $this->assertEquals('01/15/2025', $suggestions[0]->date);
+    }
+
+    public function test_valid_dates_get_full_confidence(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,expense,Store,Wallet,Food,Lunch,2025-01-15\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $suggestions);
+        $this->assertEquals(1.0, $suggestions[0]->confidence);
+    }
+
+    public function test_empty_file_returns_empty(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n";
+
+        $file = UploadedFile::fake()->createWithContent('empty.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(0, $suggestions);
+    }
+
+    public function test_supports_csv_mime_type(): void
+    {
+        $this->assertTrue($this->processor->supports('text/csv', 'csv'));
+    }
+
+    public function test_supports_csv_extension(): void
+    {
+        $this->assertTrue($this->processor->supports('application/octet-stream', 'csv'));
+    }
+
+    public function test_does_not_support_non_csv(): void
+    {
+        $this->assertFalse($this->processor->supports('application/pdf', 'pdf'));
+        $this->assertFalse($this->processor->supports('text/plain', 'txt'));
+        $this->assertFalse($this->processor->supports('image/png', 'png'));
+    }
+
+    public function test_invalid_transaction_type_sets_type_to_null(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,+Transfer,John,Wallet,Cat,Desc,2025-01-01\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $suggestions);
+        $this->assertNull($suggestions[0]->type);
+    }
+
+    public function test_case_insensitive_transaction_type(): void
+    {
+        $csv = "amount,currency,type,party,wallet,category,description,date\n"
+            . "100,USD,EXPENSE,Store,Wallet,Food,Lunch,2025-01-01\n"
+            . "200,USD,Income,Employer,Wallet,Salary,Pay,2025-01-02\n";
+
+        $file = UploadedFile::fake()->createWithContent('test.csv', $csv);
+
+        $suggestions = $this->processor->process($file, $this->user);
+
+        $this->assertCount(2, $suggestions);
+        $this->assertEquals('expense', $suggestions[0]->type);
+        $this->assertEquals('income', $suggestions[1]->type);
+    }
+}

--- a/tests/Unit/Services/DocumentProcessors/RemoteDocumentProcessorTest.php
+++ b/tests/Unit/Services/DocumentProcessors/RemoteDocumentProcessorTest.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace Tests\Unit\Services\DocumentProcessors;
+
+use App\Models\User;
+use App\Services\DocumentProcessors\RemoteDocumentProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+use Tests\TestCase;
+
+class RemoteDocumentProcessorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private RemoteDocumentProcessor $processor;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->processor = new RemoteDocumentProcessor();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_supports_returns_false_when_no_url_configured(): void
+    {
+        config(['services.document_processor.url' => null]);
+
+        $this->assertFalse($this->processor->supports('application/pdf', 'pdf'));
+        $this->assertFalse($this->processor->supports('image/png', 'png'));
+    }
+
+    public function test_supports_returns_true_for_pdf_when_url_configured(): void
+    {
+        config(['services.document_processor.url' => 'https://example.com/parse']);
+
+        $this->assertTrue($this->processor->supports('application/pdf', 'pdf'));
+    }
+
+    public function test_supports_returns_true_for_image_when_url_configured(): void
+    {
+        config(['services.document_processor.url' => 'https://example.com/parse']);
+
+        $this->assertTrue($this->processor->supports('image/png', 'png'));
+        $this->assertTrue($this->processor->supports('image/jpeg', 'jpg'));
+        $this->assertTrue($this->processor->supports('image/jpeg', 'jpeg'));
+        $this->assertTrue($this->processor->supports('image/tiff', 'tiff'));
+    }
+
+    public function test_supports_returns_false_for_unsupported_type_even_with_url(): void
+    {
+        config(['services.document_processor.url' => 'https://example.com/parse']);
+
+        $this->assertFalse($this->processor->supports('text/plain', 'txt'));
+        $this->assertFalse($this->processor->supports('text/csv', 'csv'));
+    }
+
+    public function test_process_returns_empty_when_no_url_configured(): void
+    {
+        config(['services.document_processor.url' => null]);
+
+        $file = UploadedFile::fake()->create('doc.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function test_parse_response_in_fields_mode(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'apikey',
+            'services.document_processor.auth_credentials' => 'test-key-123',
+            'services.document_processor.auth_header' => 'X-API-Key',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'fields',
+                'transactions_path' => 'transactions',
+                'date_field' => 'date',
+                'description_field' => 'description',
+                'amount_field' => 'amount',
+                'currency_field' => 'currency',
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'transactions' => [
+                    [
+                        'date' => '2025-01-15',
+                        'description' => 'Coffee Shop',
+                        'amount' => -5.50,
+                        'currency' => 'USD',
+                    ],
+                    [
+                        'date' => '2025-01-16',
+                        'description' => 'Salary deposit',
+                        'amount' => 3000.00,
+                        'currency' => 'USD',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('statement.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(2, $result);
+
+        $this->assertEquals(5.50, $result[0]->amount);
+        $this->assertEquals('expense', $result[0]->type);
+        $this->assertEquals('USD', $result[0]->currency);
+        $this->assertEquals('Coffee Shop', $result[0]->description);
+        $this->assertEquals('2025-01-15', $result[0]->date);
+        $this->assertEquals('remote', $result[0]->documentType);
+
+        $this->assertEquals(3000.00, $result[1]->amount);
+        $this->assertEquals('income', $result[1]->type);
+    }
+
+    public function test_parse_response_in_text_block_mode(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'text_block',
+                'transactions_path' => 'elements',
+                'content_field' => 'content',
+                'filter' => ['key' => 'subtype', 'value' => 'paragraph'],
+                'line_mapping' => [
+                    'date' => 0,
+                    'description' => 1,
+                    'amount' => 2,
+                    'currency' => 3,
+                ],
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'elements' => [
+                    [
+                        'subtype' => 'paragraph',
+                        'content' => "2025-03-15\nCard charge (Netflix)\n-15.99\nUSD",
+                    ],
+                    [
+                        'subtype' => 'header',
+                        'content' => 'Bank Statement',
+                    ],
+                    [
+                        'subtype' => 'paragraph',
+                        'content' => "2025-03-16\nDirect deposit\n2500.00\nUSD",
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('statement.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(2, $result);
+
+        $this->assertEquals(15.99, $result[0]->amount);
+        $this->assertEquals('expense', $result[0]->type);
+        $this->assertEquals('Netflix', $result[0]->party);
+        $this->assertEquals('Card charge (Netflix)', $result[0]->description);
+        $this->assertEquals('2025-03-15', $result[0]->date);
+
+        $this->assertEquals(2500.00, $result[1]->amount);
+        $this->assertEquals('income', $result[1]->type);
+    }
+
+    public function test_normalize_date_strips_commas(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'fields',
+                'transactions_path' => 'transactions',
+                'date_field' => 'date',
+                'amount_field' => 'amount',
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'transactions' => [
+                    [
+                        'date' => '05 Apr, 2024',
+                        'amount' => 100.00,
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('receipt.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('2024-04-05', $result[0]->date);
+    }
+
+    public function test_graceful_handling_when_remote_returns_error(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response('Internal Server Error', 500),
+        ]);
+
+        $file = UploadedFile::fake()->create('bad.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function test_auth_headers_sent_for_apikey_type(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'apikey',
+            'services.document_processor.auth_credentials' => 'my-secret-key',
+            'services.document_processor.auth_header' => 'X-API-Key',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'fields',
+                'transactions_path' => 'transactions',
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'transactions' => [],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('doc.pdf', 100, 'application/pdf');
+
+        $this->processor->process($file, $this->user);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('X-API-Key', 'my-secret-key');
+        });
+    }
+
+    public function test_bearer_auth_type(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'bearer',
+            'services.document_processor.auth_credentials' => 'my-bearer-token',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'fields',
+                'transactions_path' => 'transactions',
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'transactions' => [],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('doc.pdf', 100, 'application/pdf');
+
+        $this->processor->process($file, $this->user);
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('Authorization', 'Bearer my-bearer-token');
+        });
+    }
+
+    public function test_skipped_status_transactions_excluded_in_text_block_mode(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'text_block',
+                'transactions_path' => 'elements',
+                'content_field' => 'content',
+                'line_mapping' => [
+                    'date' => 0,
+                    'description' => 1,
+                    'amount' => 2,
+                    'currency' => 3,
+                    'status' => 4,
+                ],
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'elements' => [
+                    [
+                        'content' => "2025-01-10\nPayment\n-50.00\nUSD\ncanceled",
+                    ],
+                    [
+                        'content' => "2025-01-11\nDeposit\n100.00\nUSD\ncompleted",
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('stmt.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(100.00, $result[0]->amount);
+    }
+
+    public function test_llm_fallback_when_mapping_returns_empty(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'fields',
+                'transactions_path' => 'transactions',
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'transactions' => [],
+                'elements' => [
+                    ['content' => 'Jan 15, 2025 - Coffee purchase $5.50'],
+                ],
+            ], 200),
+        ]);
+
+        $llmResponse = json_encode([
+            [
+                'date' => '2025-01-15',
+                'description' => 'Coffee purchase',
+                'amount' => -5.50,
+                'currency' => 'USD',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $file = UploadedFile::fake()->create('receipt.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(5.50, $result[0]->amount);
+        $this->assertEquals('expense', $result[0]->type);
+        $this->assertEquals('llm_fallback', $result[0]->documentType);
+    }
+}

--- a/tests/Unit/Services/DuplicateDetectionServiceTest.php
+++ b/tests/Unit/Services/DuplicateDetectionServiceTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\DuplicateDetectionService;
+use App\Types\TransactionSuggestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DuplicateDetectionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DuplicateDetectionService $service;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new DuplicateDetectionService();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_match_same_amount_same_date_similar_description(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'description' => 'Grocery Store Purchase',
+            'type' => 'expense',
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 100.00,
+                date: '2025-01-15',
+                description: 'Grocery Store Purchase',
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(1, $results);
+        $this->assertNotNull($results[0]);
+        // Same amount + same date matches as near or exact
+        $this->assertContains($results[0]->matchType, ['exact', 'near']);
+        $this->assertGreaterThanOrEqual(0.8, $results[0]->confidence);
+    }
+
+    public function test_near_match_same_amount_date_within_3_days(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 200.00,
+            'datetime' => '2025-01-15',
+            'description' => 'Something completely different',
+            'type' => 'expense',
+        ]);
+
+        // Use two suggestions so that min/max parsedDates produce distinct Carbon objects,
+        // avoiding a Carbon mutability issue when there's only one suggestion date.
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 200.00,
+                date: '2025-01-17',
+                description: 'A totally unrelated description',
+                type: 'expense',
+            ),
+            new TransactionSuggestion(
+                amount: 999.00,
+                date: '2025-01-13',
+                description: 'Dummy to widen date range',
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(2, $results);
+        $this->assertNotNull($results[0]);
+        $this->assertEquals('near', $results[0]->matchType);
+        $this->assertEquals(0.8, $results[0]->confidence);
+        $this->assertEquals(200.00, $results[0]->transactionAmount);
+    }
+
+    public function test_similar_match_amount_within_5_percent_date_within_3_days(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'description' => 'Payment',
+            'type' => 'expense',
+        ]);
+
+        // Use two suggestions to ensure the date range query encompasses both dates
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 104.00,
+                date: '2025-01-17',
+                description: 'Something else entirely',
+                type: 'expense',
+            ),
+            new TransactionSuggestion(
+                amount: 999.00,
+                date: '2025-01-13',
+                description: 'Dummy to widen date range',
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(2, $results);
+        $this->assertNotNull($results[0]);
+        $this->assertEquals('similar', $results[0]->matchType);
+        $this->assertEquals(0.5, $results[0]->confidence);
+    }
+
+    public function test_no_match_when_amount_and_date_differ_significantly(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'description' => 'Old transaction',
+            'type' => 'expense',
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 500.00,
+                date: '2025-06-01',
+                description: 'Completely new transaction',
+                type: 'income',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]);
+    }
+
+    public function test_empty_suggestions_returns_empty_array(): void
+    {
+        $results = $this->service->checkBatch([], $this->user);
+
+        $this->assertIsArray($results);
+        $this->assertEmpty($results);
+    }
+
+    public function test_null_date_in_suggestion_returns_null_match(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'type' => 'expense',
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 100.00,
+                date: null,
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]);
+    }
+
+    public function test_null_amount_in_suggestion_returns_null_match(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'type' => 'expense',
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: null,
+                date: '2025-01-15',
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]);
+    }
+
+    public function test_no_match_when_date_exceeds_3_day_range(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'description' => 'Same description',
+            'type' => 'expense',
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 100.00,
+                date: '2025-01-20',
+                description: 'Same description',
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]);
+    }
+
+    public function test_multiple_suggestions_checked_independently(): void
+    {
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'amount' => 100.00,
+            'datetime' => '2025-01-15',
+            'description' => 'Existing transaction',
+            'type' => 'expense',
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 100.00,
+                date: '2025-01-15',
+                description: 'Existing transaction',
+                type: 'expense',
+            ),
+            new TransactionSuggestion(
+                amount: 999.00,
+                date: '2025-07-01',
+                description: 'Brand new transaction',
+                type: 'income',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(2, $results);
+        $this->assertNotNull($results[0]);
+        $this->assertContains($results[0]->matchType, ['exact', 'near']);
+        $this->assertNull($results[1]);
+    }
+
+    public function test_no_existing_transactions_returns_all_null_matches(): void
+    {
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 50.00,
+                date: '2025-01-15',
+                type: 'expense',
+            ),
+        ];
+
+        $results = $this->service->checkBatch($suggestions, $this->user);
+
+        $this->assertCount(1, $results);
+        $this->assertNull($results[0]);
+    }
+}

--- a/tests/Unit/Services/SuggestionEnricherTest.php
+++ b/tests/Unit/Services/SuggestionEnricherTest.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\User;
+use App\Services\SuggestionEnricher;
+use App\Types\TransactionSuggestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+use Tests\TestCase;
+
+class SuggestionEnricherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SuggestionEnricher $enricher;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->enricher = new SuggestionEnricher();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_empty_suggestions_returns_empty(): void
+    {
+        $result = $this->enricher->enrich([], $this->user);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function test_enrichment_merges_wallet_category_party_from_llm(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'Main Checking',
+            'currency' => 'USD',
+            'type' => 'bank',
+        ]);
+        $this->user->categories()->create([
+            'name' => 'Groceries',
+            'type' => 'expense',
+        ]);
+        $this->user->parties()->create([
+            'name' => 'SuperMart',
+            'type' => 'business',
+        ]);
+
+        $llmResponse = json_encode([
+            [
+                'wallet' => 'Main Checking',
+                'category' => 'Groceries',
+                'party' => 'SuperMart',
+                'type' => 'expense',
+                'description' => 'Weekly groceries',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 55.00,
+                currency: 'USD',
+                type: 'expense',
+                party: 'SUPRMRT #123',
+                description: 'SUPRMRT #123 Purchase',
+                date: '2025-01-15',
+                confidence: 0.8,
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Main Checking', $result[0]->wallet);
+        $this->assertEquals('Groceries', $result[0]->category);
+        $this->assertEquals('SuperMart', $result[0]->party);
+        $this->assertEquals('Weekly groceries', $result[0]->description);
+    }
+
+    public function test_enrichment_preserves_original_dates_and_amounts(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'Wallet',
+            'currency' => 'USD',
+            'type' => 'cash',
+        ]);
+
+        $llmResponse = json_encode([
+            [
+                'wallet' => 'Wallet',
+                'category' => 'Food',
+                'party' => 'Store',
+                'type' => 'expense',
+                'description' => 'Cleaned description',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 99.99,
+                currency: 'EUR',
+                date: '2025-03-20',
+                confidence: 0.9,
+                documentType: 'csv',
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(99.99, $result[0]->amount);
+        $this->assertEquals('EUR', $result[0]->currency);
+        $this->assertEquals('2025-03-20', $result[0]->date);
+        $this->assertEquals(0.9, $result[0]->confidence);
+        $this->assertEquals('csv', $result[0]->documentType);
+    }
+
+    public function test_graceful_handling_when_llm_fails(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'Wallet',
+            'currency' => 'USD',
+            'type' => 'cash',
+        ]);
+
+        // Fake Prism to throw an exception
+        Prism::fake([]);
+
+        // The fake with empty responses will return an empty text, which will
+        // fail JSON parsing. Let's instead make the LLM return invalid JSON.
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: 'THIS IS NOT JSON',
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 50.00,
+                currency: 'USD',
+                type: 'expense',
+                party: 'Original Party',
+                description: 'Original description',
+                date: '2025-01-01',
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Original Party', $result[0]->party);
+        $this->assertEquals('Original description', $result[0]->description);
+        $this->assertEquals(50.00, $result[0]->amount);
+    }
+
+    public function test_llm_response_count_mismatch_returns_originals(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'Wallet',
+            'currency' => 'USD',
+            'type' => 'cash',
+        ]);
+
+        // LLM returns 1 item but we send 2 suggestions
+        $llmResponse = json_encode([
+            [
+                'wallet' => 'Wallet',
+                'category' => 'Food',
+                'party' => 'Store',
+                'type' => 'expense',
+                'description' => 'Desc',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 10.00,
+                currency: 'USD',
+                type: 'expense',
+                description: 'First',
+                date: '2025-01-01',
+            ),
+            new TransactionSuggestion(
+                amount: 20.00,
+                currency: 'USD',
+                type: 'expense',
+                description: 'Second',
+                date: '2025-01-02',
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('First', $result[0]->description);
+        $this->assertEquals('Second', $result[1]->description);
+    }
+
+    public function test_enrichment_with_no_user_entities_still_calls_llm(): void
+    {
+        // User has no wallets, categories, or parties
+        $llmResponse = json_encode([
+            [
+                'wallet' => 'Personal Wallet',
+                'category' => 'Dining',
+                'party' => 'Restaurant',
+                'type' => 'expense',
+                'description' => 'Dinner',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 30.00,
+                currency: 'USD',
+                description: 'DNR at rest',
+                date: '2025-02-01',
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Personal Wallet', $result[0]->wallet);
+        $this->assertEquals('Dining', $result[0]->category);
+        $this->assertEquals('expense', $result[0]->type);
+    }
+
+    public function test_enrichment_strips_markdown_fences_from_llm_response(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'Wallet',
+            'currency' => 'USD',
+            'type' => 'cash',
+        ]);
+
+        $llmResponse = "```json\n" . json_encode([
+            [
+                'wallet' => 'Wallet',
+                'category' => 'Travel',
+                'party' => 'Airlines',
+                'type' => 'expense',
+                'description' => 'Flight ticket',
+            ],
+        ]) . "\n```";
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 500.00,
+                currency: 'USD',
+                description: 'AIRLINE TKT',
+                date: '2025-04-01',
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Wallet', $result[0]->wallet);
+        $this->assertEquals('Flight ticket', $result[0]->description);
+    }
+}

--- a/tests/Unit/Types/DuplicateMatchTest.php
+++ b/tests/Unit/Types/DuplicateMatchTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Types;
+
+use App\Types\DuplicateMatch;
+use PHPUnit\Framework\TestCase;
+
+class DuplicateMatchTest extends TestCase
+{
+    public function test_to_array_returns_correct_structure(): void
+    {
+        $match = new DuplicateMatch(
+            transactionId: 42,
+            matchType: 'exact',
+            confidence: 1.0,
+            transactionAmount: 99.99,
+            transactionDescription: 'Grocery store',
+            transactionDate: '2025-01-15',
+            transactionType: 'expense',
+        );
+
+        $array = $match->toArray();
+
+        $this->assertEquals([
+            'transaction_id' => 42,
+            'match_type' => 'exact',
+            'confidence' => 1.0,
+            'transaction_amount' => 99.99,
+            'transaction_description' => 'Grocery store',
+            'transaction_date' => '2025-01-15',
+            'transaction_type' => 'expense',
+        ], $array);
+    }
+
+    public function test_from_array_round_trips_correctly(): void
+    {
+        $original = new DuplicateMatch(
+            transactionId: 7,
+            matchType: 'near',
+            confidence: 0.8,
+            transactionAmount: 250.00,
+            transactionDescription: 'Monthly rent',
+            transactionDate: '2025-02-01',
+            transactionType: 'expense',
+        );
+
+        $restored = DuplicateMatch::fromArray($original->toArray());
+
+        $this->assertEquals($original->transactionId, $restored->transactionId);
+        $this->assertEquals($original->matchType, $restored->matchType);
+        $this->assertEquals($original->confidence, $restored->confidence);
+        $this->assertEquals($original->transactionAmount, $restored->transactionAmount);
+        $this->assertEquals($original->transactionDescription, $restored->transactionDescription);
+        $this->assertEquals($original->transactionDate, $restored->transactionDate);
+        $this->assertEquals($original->transactionType, $restored->transactionType);
+    }
+
+    public function test_nullable_fields_default_to_null(): void
+    {
+        $match = new DuplicateMatch(
+            transactionId: 1,
+            matchType: 'similar',
+            confidence: 0.5,
+        );
+
+        $this->assertNull($match->transactionAmount);
+        $this->assertNull($match->transactionDescription);
+        $this->assertNull($match->transactionDate);
+        $this->assertNull($match->transactionType);
+    }
+
+    public function test_to_array_includes_null_optional_fields(): void
+    {
+        $match = new DuplicateMatch(
+            transactionId: 1,
+            matchType: 'similar',
+            confidence: 0.5,
+        );
+
+        $array = $match->toArray();
+
+        $this->assertArrayHasKey('transaction_amount', $array);
+        $this->assertArrayHasKey('transaction_description', $array);
+        $this->assertArrayHasKey('transaction_date', $array);
+        $this->assertArrayHasKey('transaction_type', $array);
+        $this->assertNull($array['transaction_amount']);
+        $this->assertNull($array['transaction_description']);
+        $this->assertNull($array['transaction_date']);
+        $this->assertNull($array['transaction_type']);
+    }
+
+    public function test_from_array_casts_types_correctly(): void
+    {
+        $match = DuplicateMatch::fromArray([
+            'transaction_id' => '42',
+            'match_type' => 'exact',
+            'confidence' => '0.95',
+            'transaction_amount' => null,
+        ]);
+
+        $this->assertIsInt($match->transactionId);
+        $this->assertEquals(42, $match->transactionId);
+        $this->assertIsFloat($match->confidence);
+        $this->assertEquals(0.95, $match->confidence);
+    }
+}

--- a/tests/Unit/Types/TransactionSuggestionTest.php
+++ b/tests/Unit/Types/TransactionSuggestionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit\Types;
+
+use App\Types\TransactionSuggestion;
+use PHPUnit\Framework\TestCase;
+
+class TransactionSuggestionTest extends TestCase
+{
+    public function test_to_array_returns_correct_structure(): void
+    {
+        $suggestion = new TransactionSuggestion(
+            amount: 99.99,
+            currency: 'USD',
+            type: 'expense',
+            party: 'Amazon',
+            wallet: 'Checking',
+            category: 'Shopping',
+            description: 'Online purchase',
+            date: '2025-01-15',
+            confidence: 0.95,
+            documentType: 'csv',
+        );
+
+        $array = $suggestion->toArray();
+
+        $this->assertEquals([
+            'amount' => 99.99,
+            'currency' => 'USD',
+            'type' => 'expense',
+            'party' => 'Amazon',
+            'wallet' => 'Checking',
+            'category' => 'Shopping',
+            'description' => 'Online purchase',
+            'date' => '2025-01-15',
+            'confidence' => 0.95,
+            'document_type' => 'csv',
+        ], $array);
+    }
+
+    public function test_from_array_round_trips_correctly(): void
+    {
+        $original = new TransactionSuggestion(
+            amount: 50.0,
+            currency: 'EUR',
+            type: 'income',
+            party: 'Employer',
+            wallet: 'Savings',
+            category: 'Salary',
+            description: 'Monthly salary',
+            date: '2025-03-01',
+            confidence: 1.0,
+            documentType: 'pdf',
+        );
+
+        $restored = TransactionSuggestion::fromArray($original->toArray());
+
+        $this->assertEquals($original->amount, $restored->amount);
+        $this->assertEquals($original->currency, $restored->currency);
+        $this->assertEquals($original->type, $restored->type);
+        $this->assertEquals($original->party, $restored->party);
+        $this->assertEquals($original->wallet, $restored->wallet);
+        $this->assertEquals($original->category, $restored->category);
+        $this->assertEquals($original->description, $restored->description);
+        $this->assertEquals($original->date, $restored->date);
+        $this->assertEquals($original->confidence, $restored->confidence);
+        $this->assertEquals($original->documentType, $restored->documentType);
+    }
+
+    public function test_to_import_array_returns_positional_array_in_correct_order(): void
+    {
+        $suggestion = new TransactionSuggestion(
+            amount: 100.0,
+            currency: 'USD',
+            type: 'expense',
+            party: 'Store',
+            wallet: 'Cash',
+            category: 'Food',
+            description: 'Groceries',
+            date: '2025-06-01',
+        );
+
+        $importArray = $suggestion->toImportArray();
+
+        $this->assertCount(8, $importArray);
+        $this->assertEquals(100.0, $importArray[0]);  // amount
+        $this->assertEquals('USD', $importArray[1]);   // currency
+        $this->assertEquals('expense', $importArray[2]); // type
+        $this->assertEquals('Store', $importArray[3]); // party
+        $this->assertEquals('Cash', $importArray[4]);  // wallet
+        $this->assertEquals('Food', $importArray[5]);  // category
+        $this->assertEquals('Groceries', $importArray[6]); // description
+        $this->assertEquals('2025-06-01', $importArray[7]); // date
+    }
+
+    public function test_to_import_array_uses_empty_strings_for_null_fields(): void
+    {
+        $suggestion = new TransactionSuggestion(
+            amount: null,
+            currency: null,
+            type: null,
+        );
+
+        $importArray = $suggestion->toImportArray();
+
+        $this->assertCount(8, $importArray);
+        $this->assertEquals('', $importArray[0]);
+        $this->assertEquals('', $importArray[1]);
+        $this->assertEquals('', $importArray[2]);
+        $this->assertEquals('', $importArray[3]);
+        $this->assertEquals('', $importArray[4]);
+        $this->assertEquals('', $importArray[5]);
+        $this->assertEquals('', $importArray[6]);
+        $this->assertEquals('', $importArray[7]);
+    }
+
+    public function test_nullable_fields_default_correctly(): void
+    {
+        $suggestion = new TransactionSuggestion();
+
+        $this->assertNull($suggestion->amount);
+        $this->assertNull($suggestion->currency);
+        $this->assertNull($suggestion->type);
+        $this->assertNull($suggestion->party);
+        $this->assertNull($suggestion->wallet);
+        $this->assertNull($suggestion->category);
+        $this->assertNull($suggestion->description);
+        $this->assertNull($suggestion->date);
+        $this->assertEquals(1.0, $suggestion->confidence);
+        $this->assertNull($suggestion->documentType);
+    }
+
+    public function test_from_array_handles_missing_keys_gracefully(): void
+    {
+        $suggestion = TransactionSuggestion::fromArray([
+            'amount' => 42.0,
+        ]);
+
+        $this->assertEquals(42.0, $suggestion->amount);
+        $this->assertNull($suggestion->currency);
+        $this->assertNull($suggestion->type);
+        $this->assertNull($suggestion->party);
+        $this->assertNull($suggestion->wallet);
+        $this->assertNull($suggestion->category);
+        $this->assertNull($suggestion->description);
+        $this->assertNull($suggestion->date);
+        $this->assertEquals(1.0, $suggestion->confidence);
+        $this->assertNull($suggestion->documentType);
+    }
+
+    public function test_from_array_casts_amount_to_float(): void
+    {
+        $suggestion = TransactionSuggestion::fromArray([
+            'amount' => '123.45',
+        ]);
+
+        $this->assertIsFloat($suggestion->amount);
+        $this->assertEquals(123.45, $suggestion->amount);
+    }
+
+    public function test_from_array_casts_confidence_to_float(): void
+    {
+        $suggestion = TransactionSuggestion::fromArray([
+            'confidence' => '0.75',
+        ]);
+
+        $this->assertIsFloat($suggestion->confidence);
+        $this->assertEquals(0.75, $suggestion->confidence);
+    }
+}


### PR DESCRIPTION
- Add DocumentProcessor contract for pluggable document processing
- Add RemoteDocumentProcessor with configurable URL, auth, and response mapping
- Add CsvProcessor for structured CSV imports
- Add SuggestionEnricher (Prism LLM) for intelligent entity matching
- Add DuplicateDetectionService for exact/near/similar duplicate detection
- Add ImportSession model for analyze-review-confirm workflow
- Add AnalyzeImportJob with stage-based status updates
- Add TransactionSuggestion and DuplicateMatch readonly types
- Support bearer, API key, and basic auth for remote processors
- Support fields and text_block response mapping modes
- LLM fallback for unstructured document extraction
- Fix pre-existing ImportTest failures