### PR TITLE
feat(api): Add filtering and totals to transactions index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EXTRA_UP_INFO = \
 	echo "  MySQL:      localhost:$$FORWARD_DB_PORT"
 
 TEST_CMD = php artisan test --coverage
-LINT_CMD = composer phpcs:test && composer phpmd && composer pint:test
+LINT_CMD = sh -c "composer phpcs:test && composer phpmd && composer pint:test && composer openapi:test"
 
 # ──────────────────────────────────────────────
 # Include shared targets from laravel.mk
@@ -34,7 +34,9 @@ include laravel.mk
 # Trakli-specific targets
 # ──────────────────────────────────────────────
 
-.PHONY: phpmd phpstan format format-fix openapi openapi-test prod-build prod-push prod-up prod-down
+.PHONY: phpmd phpstan format format-fix openapi openapi-test ci prod-build prod-push prod-up prod-down
+
+ci: lint test ## Run every check that CI runs (lint + tests with coverage)
 
 phpmd: ## Run mess detector
 	$(EXEC) composer phpmd

--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -37,8 +37,43 @@ class TransactionController extends ApiController
                 name: 'type',
                 description: 'Type of transaction (income/expense)',
                 in: 'query',
-                required: true,
+                required: false,
                 schema: new OA\Schema(type: 'string', enum: ['income', 'expense'])
+            ),
+            new OA\Parameter(
+                name: 'date_from',
+                description: 'Filter transactions from this date (YYYY-MM-DD)',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', format: 'date')
+            ),
+            new OA\Parameter(
+                name: 'date_to',
+                description: 'Filter transactions up to this date (YYYY-MM-DD)',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', format: 'date')
+            ),
+            new OA\Parameter(
+                name: 'wallet_ids[]',
+                description: 'Filter by wallet IDs',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer'))
+            ),
+            new OA\Parameter(
+                name: 'category_ids[]',
+                description: 'Filter by category IDs',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer'))
+            ),
+            new OA\Parameter(
+                name: 'search',
+                description: 'Search transactions by description',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string')
             ),
             new OA\Parameter(ref: '#/components/parameters/limitParam'),
             new OA\Parameter(ref: '#/components/parameters/syncedSinceParam'),
@@ -82,8 +117,19 @@ class TransactionController extends ApiController
             $query->where('type', $type);
         }
 
+        $this->applyTransactionFilters($query, $request);
+
         try {
+            // Compute totals for the filtered query (before pagination)
+            $totalsQuery = clone $query;
+            $totals = [
+                'income' => (float) (clone $totalsQuery)->where('type', 'income')->sum('amount'),
+                'expenses' => (float) (clone $totalsQuery)->where('type', 'expense')->sum('amount'),
+            ];
+            $totals['net'] = $totals['income'] - $totals['expenses'];
+
             $data = $this->applyApiQuery($request, $query);
+            $data['totals'] = $totals;
 
             return $this->success($data);
         } catch (\InvalidArgumentException $e) {
@@ -786,6 +832,55 @@ class TransactionController extends ApiController
         $transaction->delete();
 
         return $this->success(['message' => __('Transaction deleted successfully')]);
+    }
+
+    /**
+     * Apply optional filtering query parameters (date range, wallets,
+     * categories, search) to the given transaction query.
+     */
+    private function applyTransactionFilters($query, Request $request): void
+    {
+        if ($request->filled('date_from')) {
+            $query->whereDate('datetime', '>=', $request->query('date_from'));
+        }
+
+        if ($request->filled('date_to')) {
+            $query->whereDate('datetime', '<=', $request->query('date_to'));
+        }
+
+        $walletIds = $request->query('wallet_ids');
+        if (! empty($walletIds)) {
+            $walletIds = is_array($walletIds) ? $walletIds : [$walletIds];
+            $query->whereIn('wallet_id', $walletIds);
+        }
+
+        $categoryIds = $request->query('category_ids');
+        if (! empty($categoryIds)) {
+            $categoryIds = is_array($categoryIds) ? $categoryIds : [$categoryIds];
+            $query->whereHas('categories', function ($q) use ($categoryIds) {
+                $q->whereIn('categories.id', $categoryIds);
+            });
+        }
+
+        if ($request->filled('search')) {
+            $this->applySearchFilter($query, (string) $request->query('search'));
+        }
+    }
+
+    /**
+     * Apply a free-text search filter that matches against the description
+     * and, when the query contains a number, also the exact amount.
+     */
+    private function applySearchFilter($query, string $search): void
+    {
+        $query->where(function ($q) use ($search) {
+            $q->where('description', 'LIKE', '%' . $search . '%');
+
+            $numeric = preg_replace('/[^0-9.]/', '', $search);
+            if ($numeric !== '' && is_numeric($numeric)) {
+                $q->orWhere('amount', $numeric);
+            }
+        });
     }
 
     /**

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2351,13 +2351,66 @@
                         "name": "type",
                         "in": "query",
                         "description": "Type of transaction (income/expense)",
-                        "required": true,
+                        "required": false,
                         "schema": {
                             "type": "string",
                             "enum": [
                                 "income",
                                 "expense"
                             ]
+                        }
+                    },
+                    {
+                        "name": "date_from",
+                        "in": "query",
+                        "description": "Filter transactions from this date (YYYY-MM-DD)",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "date_to",
+                        "in": "query",
+                        "description": "Filter transactions up to this date (YYYY-MM-DD)",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "wallet_ids[]",
+                        "in": "query",
+                        "description": "Filter by wallet IDs",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "name": "category_ids[]",
+                        "in": "query",
+                        "description": "Filter by category IDs",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Search transactions by description",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {


### PR DESCRIPTION
Adds date_from, date_to, wallet_ids[], category_ids[] and search query parameters to GET /transactions. Search matches description and exact amount when a numeric value is provided. Response now includes income, expenses and net totals for the filtered set across all pages.