### PR TITLE
feat(import): Make auto-creation of entities configurable during import

### DIFF
--- a/app/Http/Controllers/API/v1/ImportController.php
+++ b/app/Http/Controllers/API/v1/ImportController.php
@@ -257,7 +257,10 @@ class ImportController extends ApiController
                         $this->fileImportService->importTransaction(
                             $this->convertImportObjectToArray($importToFix),
                             $transactionType,
-                            $user
+                            $user,
+                            autoCreateWallets: true,
+                            autoCreateParties: true,
+                            autoCreateCategories: true,
                         );
                     } catch (\Exception $e) {
                         $importToFix['reason'] = 'An error occurred while importing this transaction';
@@ -396,6 +399,9 @@ class ImportController extends ApiController
                 properties: [
                     new OA\Property(property: 'session_id', type: 'integer'),
                     new OA\Property(property: 'accepted', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'auto_create_wallets', type: 'boolean', default: false, description: 'Create wallets that do not exist'),
+                    new OA\Property(property: 'auto_create_parties', type: 'boolean', default: false, description: 'Create parties that do not exist'),
+                    new OA\Property(property: 'auto_create_categories', type: 'boolean', default: false, description: 'Create categories that do not exist'),
                 ]
             )
         ),
@@ -421,11 +427,16 @@ class ImportController extends ApiController
 
         $suggestions = $session->suggestions;
         $accepted = $request->input('accepted');
+        $autoCreate = [
+            'wallets' => $request->boolean('auto_create_wallets', false),
+            'parties' => $request->boolean('auto_create_parties', false),
+            'categories' => $request->boolean('auto_create_categories', false),
+        ];
         $createdCount = 0;
         $errors = [];
 
         foreach ($accepted as $item) {
-            $result = $this->processAcceptedItem($item, $suggestions, $user);
+            $result = $this->processAcceptedItem($item, $suggestions, $user, $autoCreate);
 
             if ($result === true) {
                 $createdCount++;
@@ -434,12 +445,16 @@ class ImportController extends ApiController
             }
         }
 
-        $session->update(['status' => 'confirmed']);
-
         $data = [
             'created_count' => $createdCount,
             'errors' => $errors,
         ];
+
+        if ($createdCount === 0 && ! empty($errors)) {
+            return $this->success($data, __('Import failed. No transactions were created.'), 206);
+        }
+
+        $session->update(['status' => 'confirmed']);
 
         if (! empty($errors)) {
             return $this->success($data, __('Import completed with some errors.'), 206);
@@ -453,7 +468,7 @@ class ImportController extends ApiController
      *
      * @return true|string True on success, error message string on failure
      */
-    private function processAcceptedItem(array $item, array $suggestions, $user): true|string
+    private function processAcceptedItem(array $item, array $suggestions, $user, array $autoCreate = []): true|string
     {
         $index = $item['index'];
 
@@ -473,7 +488,10 @@ class ImportController extends ApiController
             $this->fileImportService->importTransaction(
                 $suggestionObj->toImportArray(),
                 $transactionType,
-                $user
+                $user,
+                autoCreateWallets: $autoCreate['wallets'],
+                autoCreateParties: $autoCreate['parties'],
+                autoCreateCategories: $autoCreate['categories'],
             );
 
             return true;

--- a/app/Http/Requests/ImportConfirmRequest.php
+++ b/app/Http/Requests/ImportConfirmRequest.php
@@ -20,6 +20,9 @@ class ImportConfirmRequest extends FormRequest
             'accepted.*.category' => 'nullable|string',
             'accepted.*.description' => 'nullable|string',
             'accepted.*.date' => 'nullable|date_format:Y-m-d',
+            'auto_create_wallets' => 'nullable|boolean',
+            'auto_create_parties' => 'nullable|boolean',
+            'auto_create_categories' => 'nullable|boolean',
         ];
     }
 }

--- a/app/Services/FileImportService.php
+++ b/app/Services/FileImportService.php
@@ -68,7 +68,14 @@ class FileImportService
                 $transactionType = strtolower(trim($data[2]));
                 if (in_array($transactionType, [TransactionType::EXPENSE->value, TransactionType::INCOME->value])) {
                     try {
-                        $this->importTransaction($data, $transactionType, $user);
+                        $this->importTransaction(
+                            $data,
+                            $transactionType,
+                            $user,
+                            autoCreateWallets: true,
+                            autoCreateParties: true,
+                            autoCreateCategories: true,
+                        );
                     } catch (FileImportException $e) {
                         $this->saveFailedImport($fileImport, $data, $user, $e->getMessage());
                         Log::error($e);
@@ -166,9 +173,15 @@ class FileImportService
      *
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function importTransaction(array $data, string $transactionType, User $user): void
-    {
-        DB::transaction(function () use ($user, $transactionType, $data) {
+    public function importTransaction(
+        array $data,
+        string $transactionType,
+        User $user,
+        bool $autoCreateWallets = false,
+        bool $autoCreateParties = false,
+        bool $autoCreateCategories = false,
+    ): void {
+        DB::transaction(function () use ($user, $transactionType, $data, $autoCreateWallets, $autoCreateParties, $autoCreateCategories) {
             // get the data we need
 
             $amount = floatval($data[0]);
@@ -182,14 +195,13 @@ class FileImportService
             $existingParty = null;
 
             if (! empty($wallet)) {
-                // check if the wallet exists, if not create a new wallet
                 if (empty($currency)) {
                     $existingWallet = $user->wallets()->where('name', $wallet)->first();
                 } else {
                     $existingWallet = $user->wallets()->where('name', $wallet)->where('currency', $currency)->first();
                 }
 
-                if (is_null($existingWallet) && ! empty($currency)) {
+                if (is_null($existingWallet) && ! empty($currency) && $autoCreateWallets) {
                     $existingWallet = $user->wallets()->create([
                         'name' => $wallet,
                         'currency' => $currency,
@@ -198,9 +210,8 @@ class FileImportService
             }
 
             if (! empty($party)) {
-                // check if the party exists, if not create a new party
                 $existingParty = $user->parties()->where('name', $party)->first();
-                if (is_null($existingParty)) {
+                if (is_null($existingParty) && $autoCreateParties) {
                     $existingParty = $user->parties()->create([
                         'name' => $party,
                     ]);
@@ -223,16 +234,17 @@ class FileImportService
             $transaction = $user->transactions()->create($transactionData);
 
             if (! empty($category)) {
-                // check if the category exists, if not create a new category
                 $existingCategory = $user->categories()->where('name', $category)->first();
-                if (is_null($existingCategory)) {
+                if (is_null($existingCategory) && $autoCreateCategories) {
                     $existingCategory = $user->categories()->create([
                         'type' => $transactionType,
                         'name' => $category,
                     ]);
                 }
 
-                $transaction->categories()->sync([$existingCategory->id]);
+                if (! is_null($existingCategory)) {
+                    $transaction->categories()->sync([$existingCategory->id]);
+                }
             }
         });
     }

--- a/app/Services/SuggestionEnricher.php
+++ b/app/Services/SuggestionEnricher.php
@@ -22,7 +22,7 @@ class SuggestionEnricher
             return [];
         }
 
-        $wallets = $user->wallets()->select('name', 'currency')->get()->toArray();
+        $wallets = $user->wallets()->select('name', 'currency', 'slug')->get()->toArray();
         $categories = $user->categories()->select('name', 'type')->get()->toArray();
         $parties = $user->parties()->select('name')->get()->toArray();
 
@@ -55,7 +55,7 @@ class SuggestionEnricher
             $enriched = $this->parseResponse($response->text);
 
             if (is_array($enriched) && count($enriched) === count($suggestions)) {
-                return $this->mergeEnrichments($suggestions, $enriched);
+                return $this->mergeEnrichments($suggestions, $enriched, $wallets);
             }
 
             Log::warning('SuggestionEnricher: LLM response count mismatch', [
@@ -158,19 +158,35 @@ PROMPT;
      * @param  TransactionSuggestion[]  $suggestions
      * @return TransactionSuggestion[]
      */
-    private function mergeEnrichments(array $suggestions, array $enrichments): array
+    private function mergeEnrichments(array $suggestions, array $enrichments, array $wallets): array
     {
+        $walletsBySlug = [];
+        $slugByName = [];
+        foreach ($wallets as $w) {
+            $walletsBySlug[$w['slug']] = $w;
+            $slugByName[$w['name']] = $w['slug'];
+        }
+
         $result = [];
 
         foreach ($suggestions as $i => $suggestion) {
             $enrichment = $enrichments[$i] ?? [];
+            $assignedWallet = $enrichment['wallet'] ?? $suggestion->wallet;
+
+            $currency = $suggestion->currency;
+            if ($assignedWallet) {
+                $slug = $slugByName[$assignedWallet] ?? null;
+                if ($slug && isset($walletsBySlug[$slug])) {
+                    $currency = $walletsBySlug[$slug]['currency'];
+                }
+            }
 
             $result[] = new TransactionSuggestion(
                 amount: $suggestion->amount,
-                currency: $suggestion->currency,
+                currency: $currency,
                 type: $enrichment['type'] ?? $suggestion->type,
                 party: $enrichment['party'] ?? $suggestion->party,
-                wallet: $enrichment['wallet'] ?? $suggestion->wallet,
+                wallet: $assignedWallet,
                 category: $enrichment['category'] ?? $suggestion->category,
                 description: $enrichment['description'] ?? $suggestion->description,
                 date: $suggestion->date,

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -1220,6 +1220,21 @@
                                         "items": {
                                             "type": "object"
                                         }
+                                    },
+                                    "auto_create_wallets": {
+                                        "description": "Create wallets that do not exist",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "auto_create_parties": {
+                                        "description": "Create parties that do not exist",
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "auto_create_categories": {
+                                        "description": "Create categories that do not exist",
+                                        "type": "boolean",
+                                        "default": false
                                     }
                                 },
                                 "type": "object"

--- a/tests/Feature/AdvancedImportTest.php
+++ b/tests/Feature/AdvancedImportTest.php
@@ -112,6 +112,9 @@ class AdvancedImportTest extends TestCase
                 ['index' => 0],
                 ['index' => 1],
             ],
+            'auto_create_wallets' => true,
+            'auto_create_parties' => true,
+            'auto_create_categories' => true,
         ]);
 
         $response->assertStatus(200);
@@ -329,6 +332,9 @@ class AdvancedImportTest extends TestCase
                     'description' => 'Edited description',
                 ],
             ],
+            'auto_create_wallets' => true,
+            'auto_create_parties' => true,
+            'auto_create_categories' => true,
         ]);
 
         $response->assertStatus(200);
@@ -416,6 +422,9 @@ class AdvancedImportTest extends TestCase
                     'amount' => 80.00,
                 ],
             ],
+            'auto_create_wallets' => true,
+            'auto_create_parties' => true,
+            'auto_create_categories' => true,
         ]);
 
         $response->assertStatus(200);
@@ -556,6 +565,9 @@ class AdvancedImportTest extends TestCase
                     'type' => 'income',
                 ],
             ],
+            'auto_create_wallets' => true,
+            'auto_create_parties' => true,
+            'auto_create_categories' => true,
         ]);
 
         $response->assertStatus(200);
@@ -563,5 +575,162 @@ class AdvancedImportTest extends TestCase
         $transaction = $this->user->transactions()->first();
         $this->assertNotNull($transaction);
         $this->assertEquals('income', $transaction->type);
+    }
+
+    public function test_confirm_does_not_auto_create_entities_by_default(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 50.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'New Store',
+                    'wallet' => 'New Wallet',
+                    'category' => 'New Category',
+                    'description' => 'Test purchase',
+                    'date' => '2025-03-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        // No auto_create flags — defaults to false
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 0],
+            ],
+        ]);
+
+        // Import should fail because wallet doesn't exist and wasn't auto-created
+        $response->assertStatus(206);
+
+        $data = $response->json('data');
+        $this->assertEquals(0, $data['created_count']);
+        $this->assertNotEmpty($data['errors']);
+
+        // No entities should have been created
+        $this->assertEquals(0, $this->user->wallets()->count());
+        $this->assertEquals(0, $this->user->parties()->count());
+        $this->assertEquals(0, $this->user->categories()->count());
+        $this->assertEquals(0, $this->user->transactions()->count());
+    }
+
+    public function test_confirm_respects_granular_auto_create_flags(): void
+    {
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 75.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'New Party',
+                    'wallet' => 'New Wallet',
+                    'category' => 'New Category',
+                    'description' => 'Granular test',
+                    'date' => '2025-03-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        // Enable auto-create for wallets and parties only
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 0],
+            ],
+            'auto_create_wallets' => true,
+            'auto_create_parties' => true,
+            'auto_create_categories' => false,
+        ]);
+
+        $response->assertStatus(200);
+
+        $transaction = $this->user->transactions()->first();
+        $this->assertNotNull($transaction);
+
+        // Wallet should be created and linked
+        $this->assertEquals(1, $this->user->wallets()->count());
+        $this->assertNotNull($transaction->wallet_id);
+
+        // Party should be created and linked
+        $this->assertEquals(1, $this->user->parties()->count());
+        $this->assertNotNull($transaction->party_id);
+        $this->assertEquals('New Party', $this->user->parties()->first()->name);
+
+        // Category should NOT be created
+        $this->assertEquals(0, $this->user->categories()->count());
+        $this->assertEquals(0, $transaction->categories()->count());
+    }
+
+    public function test_confirm_matches_existing_entities_without_auto_create(): void
+    {
+        // Pre-create entities
+        $wallet = $this->user->wallets()->create(['name' => 'My Wallet', 'currency' => 'USD']);
+        $party = $this->user->parties()->create(['name' => 'My Store']);
+        $category = $this->user->categories()->create(['name' => 'Groceries', 'type' => 'expense']);
+
+        $session = $this->user->importSessions()->create([
+            'file_name' => 'test.csv',
+            'file_type' => 'csv',
+            'document_type' => null,
+            'processor' => 'CsvProcessor',
+            'status' => 'ready',
+            'suggestions' => [
+                [
+                    'amount' => 30.00,
+                    'currency' => 'USD',
+                    'type' => 'expense',
+                    'party' => 'My Store',
+                    'wallet' => 'My Wallet',
+                    'category' => 'Groceries',
+                    'description' => 'Weekly shop',
+                    'date' => '2025-03-01',
+                    'confidence' => 1.0,
+                    'document_type' => 'csv',
+                    'duplicate' => null,
+                ],
+            ],
+        ]);
+
+        // No auto-create flags — should still match existing entities
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [
+                ['index' => 0],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $transaction = $this->user->transactions()->first();
+        $this->assertNotNull($transaction);
+
+        // Should link to existing entities without creating new ones
+        $this->assertEquals($wallet->id, $transaction->wallet_id);
+        $this->assertEquals($party->id, $transaction->party_id);
+        $this->assertEquals(1, $transaction->categories()->count());
+        $this->assertEquals($category->id, $transaction->categories()->first()->id);
+
+        // No additional entities created
+        $this->assertEquals(1, $this->user->wallets()->count());
+        $this->assertEquals(1, $this->user->parties()->count());
+        $this->assertEquals(1, $this->user->categories()->count());
     }
 }

--- a/tests/Unit/Services/SuggestionEnricherTest.php
+++ b/tests/Unit/Services/SuggestionEnricherTest.php
@@ -141,7 +141,7 @@ class SuggestionEnricherTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertEquals(99.99, $result[0]->amount);
-        $this->assertEquals('EUR', $result[0]->currency);
+        $this->assertEquals('USD', $result[0]->currency);
         $this->assertEquals('2025-03-20', $result[0]->date);
         $this->assertEquals(0.9, $result[0]->confidence);
         $this->assertEquals('csv', $result[0]->documentType);


### PR DESCRIPTION
Previously, wallets, parties, and categories were silently created when they didn't exist during import confirmation. Now auto-creation defaults to off and is controlled per-entity via API flags.

The enricher now corrects the currency field to match the assigned wallet, preventing mismatches from bad extraction data. Sessions are no longer marked confirmed when all items fail, allowing users to retry.