### PR TITLE
fix(notifications): Accept client_id and read_at on mark-as-read

### DIFF
--- a/app/Http/Controllers/API/v1/NotificationController.php
+++ b/app/Http/Controllers/API/v1/NotificationController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
 use App\Http\Traits\ApiQueryable;
+use App\Rules\Iso8601DateTime;
+use App\Rules\ValidateClientId;
 use App\Services\NotificationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -97,18 +99,49 @@ class NotificationController extends ApiController
 
     #[OA\Post(
         path: '/notifications/{id}/read',
-        summary: 'Mark a notification as read',
+        summary: 'Mark a notification as read or sync its client_id',
+        description: 'Marks the notification as read using the supplied read_at (or now() if omitted). '
+            . 'If only client_id is sent, the server records the client_id without changing read state, '
+            . 'so the mobile sync can establish the link before the user opens the notification.',
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(
+                        property: 'client_id',
+                        description: 'Client-generated identifier for offline sync. Optional.',
+                        type: 'string',
+                        example: '245cb3df-df3a-428b-a908-e5f74b8d58a3:245cb3df-df3a-428b-a908-e5f74b8d58a4'
+                    ),
+                    new OA\Property(
+                        property: 'read_at',
+                        description: 'Timestamp the notification was read on the client. Optional. '
+                            . 'When omitted and client_id is also omitted, the server uses the current time. '
+                            . 'When omitted and client_id is present, read state is left unchanged.',
+                        type: 'string',
+                        format: 'date-time'
+                    ),
+                ],
+                type: 'object'
+            )
+        ),
         tags: ['Notifications'],
         parameters: [
             new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
         ],
         responses: [
-            new OA\Response(response: 200, description: 'Notification marked as read'),
+            new OA\Response(response: 200, description: 'Notification marked as read or synced'),
             new OA\Response(response: 404, description: 'Notification not found'),
+            new OA\Response(response: 422, description: 'Validation error'),
         ]
     )]
     public function markAsRead(Request $request, int $notificationId): JsonResponse
     {
+        $validatedData = $request->validate([
+            'client_id' => ['nullable', 'string', new ValidateClientId()],
+            'read_at' => ['nullable', new Iso8601DateTime()],
+        ]);
+
         $user = $request->user();
         $notification = $user->notifications()->find($notificationId);
 
@@ -116,9 +149,32 @@ class NotificationController extends ApiController
             return $this->failure(__('Notification not found'), 404);
         }
 
-        $notification->markAsRead();
+        $hasClientId = isset($validatedData['client_id']);
+        $hasReadAt = isset($validatedData['read_at']);
+        // Mobile sync may push the client_id before the user has actually read
+        // the notification. Only mark as read when the caller explicitly sends
+        // read_at, or when neither field is sent (legacy "just mark me read").
+        $shouldMarkRead = $hasReadAt || ! $hasClientId;
 
-        return $this->success($notification, __('Notification marked as read'));
+        if ($shouldMarkRead && ! $notification->isRead()) {
+            $notification->read_at = $hasReadAt
+                ? format_iso8601_to_sql($validatedData['read_at'])
+                : now();
+            $notification->save();
+        }
+
+        if ($hasClientId && ! $notification->client_generated_id) {
+            $notification->setClientGeneratedId($validatedData['client_id'], $user);
+        }
+
+        $notification->markAsSynced();
+        $notification->refresh();
+
+        $message = $shouldMarkRead
+            ? __('Notification marked as read')
+            : __('Notification synced');
+
+        return $this->success($notification, $message);
     }
 
     #[OA\Post(

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2070,7 +2070,8 @@
                 "tags": [
                     "Notifications"
                 ],
-                "summary": "Mark a notification as read",
+                "summary": "Mark a notification as read or sync its client_id",
+                "description": "Marks the notification as read using the supplied read_at (or now() if omitted). If only client_id is sent, the server records the client_id without changing read state, so the mobile sync can establish the link before the user opens the notification.",
                 "operationId": "057bc4edab5f0e13b8b89356e8155f58",
                 "parameters": [
                     {
@@ -2082,12 +2083,37 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "client_id": {
+                                        "description": "Client-generated identifier for offline sync. Optional.",
+                                        "type": "string",
+                                        "example": "245cb3df-df3a-428b-a908-e5f74b8d58a3:245cb3df-df3a-428b-a908-e5f74b8d58a4"
+                                    },
+                                    "read_at": {
+                                        "description": "Timestamp the notification was read on the client. Optional. When omitted and client_id is also omitted, the server uses the current time. When omitted and client_id is present, read state is left unchanged.",
+                                        "type": "string",
+                                        "format": "date-time"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
-                        "description": "Notification marked as read"
+                        "description": "Notification marked as read or synced"
                     },
                     "404": {
                         "description": "Notification not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
                     }
                 }
             }

--- a/tests/Feature/IntegerTypeConsistencyTest.php
+++ b/tests/Feature/IntegerTypeConsistencyTest.php
@@ -92,7 +92,7 @@ class IntegerTypeConsistencyTest extends TestCase
 
         $updateResponse = $this->actingAs($this->user)->putJson("/api/v1/transactions/{$transactionId}", [
             'amount' => 200,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $updateResponse->assertStatus(200);
@@ -126,7 +126,7 @@ class IntegerTypeConsistencyTest extends TestCase
 
         $updateResponse = $this->actingAs($this->user)->putJson("/api/v1/transactions/{$transactionId}", [
             'wallet_id' => $newWallet->id,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $updateResponse->assertStatus(200);

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -92,6 +92,128 @@ class NotificationTest extends TestCase
         $this->assertNotNull($notification->fresh()->read_at);
     }
 
+    public function test_mark_as_read_uses_supplied_read_at_timestamp()
+    {
+        $notification = Notification::factory()->create([
+            'user_id' => $this->user->id,
+            'read_at' => null,
+        ]);
+
+        $readAt = now()->subHours(3);
+
+        $response = $this->actingAs($this->user)->postJson(
+            "/api/v1/notifications/{$notification->id}/read",
+            ['read_at' => $readAt->toIso8601String()],
+        );
+
+        $response->assertStatus(200);
+        $this->assertEquals(
+            $readAt->startOfSecond()->timestamp,
+            $notification->fresh()->read_at->timestamp,
+        );
+    }
+
+    public function test_mark_as_read_with_client_id_only_does_not_mark_read()
+    {
+        $notification = Notification::factory()->create([
+            'user_id' => $this->user->id,
+            'read_at' => null,
+        ]);
+
+        $deviceId = '245cb3df-df3a-428b-a908-e5f74b8d58a4';
+        $randomId = '245cb3df-df3a-428b-a908-e5f74b8d58a5';
+
+        $response = $this->actingAs($this->user)->postJson(
+            "/api/v1/notifications/{$notification->id}/read",
+            ['client_id' => "$deviceId:$randomId"],
+        );
+
+        $response->assertStatus(200);
+        $this->assertNull($notification->fresh()->read_at);
+        $this->assertEquals($randomId, $notification->fresh()->syncState->client_generated_id);
+    }
+
+    public function test_mark_as_read_with_client_id_and_read_at_sets_both()
+    {
+        $notification = Notification::factory()->create([
+            'user_id' => $this->user->id,
+            'read_at' => null,
+        ]);
+
+        $deviceId = '245cb3df-df3a-428b-a908-e5f74b8d58a4';
+        $randomId = '245cb3df-df3a-428b-a908-e5f74b8d58a6';
+        $readAt = now()->subMinutes(10);
+
+        $response = $this->actingAs($this->user)->postJson(
+            "/api/v1/notifications/{$notification->id}/read",
+            [
+                'client_id' => "$deviceId:$randomId",
+                'read_at' => $readAt->toIso8601String(),
+            ],
+        );
+
+        $response->assertStatus(200);
+        $fresh = $notification->fresh();
+        $this->assertNotNull($fresh->read_at);
+        $this->assertEquals($randomId, $fresh->syncState->client_generated_id);
+    }
+
+    public function test_mark_as_read_does_not_overwrite_existing_read_at()
+    {
+        $originalReadAt = now()->subDays(2)->startOfSecond();
+        $notification = Notification::factory()->create([
+            'user_id' => $this->user->id,
+            'read_at' => $originalReadAt,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            "/api/v1/notifications/{$notification->id}/read",
+            ['read_at' => now()->toIso8601String()],
+        );
+
+        $response->assertStatus(200);
+        $this->assertEquals(
+            $originalReadAt->timestamp,
+            $notification->fresh()->read_at->timestamp,
+        );
+    }
+
+    public function test_mark_as_read_rejects_invalid_client_id()
+    {
+        $notification = Notification::factory()->create([
+            'user_id' => $this->user->id,
+            'read_at' => null,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            "/api/v1/notifications/{$notification->id}/read",
+            ['client_id' => 'not-a-valid-client-id'],
+        );
+
+        $response->assertStatus(422);
+        $this->assertStringContainsString(
+            'must be in the format',
+            $response->json('errors.client_id.0'),
+        );
+        $this->assertNull($notification->fresh()->read_at);
+    }
+
+    public function test_mark_as_read_rejects_invalid_read_at()
+    {
+        $notification = Notification::factory()->create([
+            'user_id' => $this->user->id,
+            'read_at' => null,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson(
+            "/api/v1/notifications/{$notification->id}/read",
+            ['read_at' => 'not-a-date'],
+        );
+
+        $response->assertStatus(422);
+        $this->assertNull($notification->fresh()->read_at);
+    }
+
     public function test_user_can_mark_all_notifications_as_read()
     {
         Notification::factory()->count(5)->create([

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -355,7 +355,7 @@ class TransactionsTest extends TestCase
 
         $response = $this->actingAs($this->user)->putJson('/api/v1/transactions/'.$expense['id'], [
             'amount' => 200,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $response->assertStatus(200)
@@ -472,7 +472,7 @@ class TransactionsTest extends TestCase
             'recurrence_period' => 'daily',
             'recurrence_interval' => 2,
             'is_recurring' => true,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $transaction = $response->json('data');
@@ -505,7 +505,7 @@ class TransactionsTest extends TestCase
             'recurrence_period' => 'weekly',
             'recurrence_interval' => 2,
             'is_recurring' => true,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $transaction = $response->json('data');
@@ -704,7 +704,7 @@ class TransactionsTest extends TestCase
             'recurrence_period' => 'weekly',
             'recurrence_interval' => 2,
             'is_recurring' => true,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $response->assertStatus(200);
@@ -729,7 +729,7 @@ class TransactionsTest extends TestCase
             'recurrence_period' => 'monthly',
             'recurrence_interval' => 1,
             'is_recurring' => true,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $response->assertStatus(200);
@@ -757,7 +757,7 @@ class TransactionsTest extends TestCase
         // Remove recurrence by setting is_recurring to false
         $response = $this->actingAs($this->user)->putJson('/api/v1/transactions/'.$transaction['id'], [
             'is_recurring' => false,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
         ]);
 
         $response->assertStatus(200);
@@ -776,7 +776,7 @@ class TransactionsTest extends TestCase
 
         $response = $this->actingAs($this->user)->putJson('/api/v1/transactions/'.$expense['id'], [
             'amount' => 200,
-            'updated_at' => '2026-05-01T15:17:54.120Z',
+            'updated_at' => now()->addSecond()->toIso8601String(),
             'client_id' => "$deviceToken:$clientId",
         ]);
 


### PR DESCRIPTION
Mark-as-read now accepts an optional client_id and an optional read_at from the caller, so the mobile app's offline sync can establish the client_id link in a separate call from the actual mark-read action.

When only client_id is sent the read state is left untouched, letting the sync push the link before the user opens the notification. When read_at is sent it is honored as the read time, so the timestamp reflects when the user tapped, not when sync ran. An empty body keeps the legacy behavior of marking read with the current server time.

Already-read notifications keep their original read_at on subsequent calls, so re-syncing doesn't shift the timestamp.