### PR TITLE
chore(release): Prepare 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-05-18
+
+### Fixed
+
+- Brand logo in outgoing emails now renders consistently across desktop, web, and mobile mail clients; the previous inline SVG was being stripped or ignored
+
 ## [1.1.1] - 2026-05-03
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "trakli/webservice",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "type": "project",
     "description": "Trakli Webservice",
     "keywords": [


### PR DESCRIPTION
Bumps webservice to 1.1.2. CHANGELOG covers the patch: the brand logo in outgoing emails switched to a hosted PNG so it renders reliably across mail clients (the inline SVG was being stripped or ignored).