### PR TITLE
fix(deploy): Use short commit hashes and a valid FlatRun action ref

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,6 +28,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve short commit SHA
+        id: meta
+        if: ${{ github.event_name == 'push' }}
+        run: echo "sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push commit image
         if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v4
@@ -35,7 +40,7 @@ jobs:
           context: .
           file: docker/prod/Dockerfile
           push: true
-          tags: ghcr.io/trakli/webservice:${{ github.sha }}
+          tags: ghcr.io/trakli/webservice:${{ steps.meta.outputs.sha }}
 
       - name: Build and push latest
         if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,18 @@ jobs:
 
     steps:
       - name: Setup FlatRun
-        uses: flatrun/actions/setup-flatrun@v1
+        uses: flatrun/actions/setup-flatrun@main
         with:
           version: 0.2.0
 
+      - name: Resolve short commit SHA
+        id: meta
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy
-        run: flatrun deployment image set trakli-staging app ghcr.io/trakli/webservice:${{ github.event.workflow_run.head_sha }} --deploy
+        run: flatrun deployment image set trakli-staging app ghcr.io/trakli/webservice:${{ steps.meta.outputs.sha }} --deploy
 
       - name: Run database migrations
         run: flatrun deployment exec trakli-staging app -- php artisan migrate


### PR DESCRIPTION
Per-commit images are now tagged and deployed with a short commit hash instead of the full-length one.

The staging deploy also referenced a FlatRun setup action version that does not exist, so the deploy failed while resolving actions before any step ran; it now points at the action's published branch.