### PR TITLE
fix: Report the current app version in the API docs

### DIFF
--- a/app/Http/Controllers/API/ApiController.php
+++ b/app/Http/Controllers/API/ApiController.php
@@ -14,7 +14,7 @@ use OpenApi\Attributes as OA;
         ['bearerAuth' => []],
     ]
 )]
-#[OA\Info(version: '1.0.0', title: 'Trakli API')]
+#[OA\Info(version: '1.1.2', title: 'Trakli API')]
 #[OA\Server(url: 'http://localhost:8000/api/v1', description: 'Local server')]
 #[OA\Server(url: 'https://api.dev.trakli.app/api/v1', description: 'Development server')]
 #[OA\Server(

--- a/composer.json
+++ b/composer.json
@@ -77,10 +77,11 @@
             "vendor/bin/pint --preset psr12 --test"
         ],
         "openapi": [
-            "./vendor/bin/openapi app --debug --output public/docs/api.json"
+            "./vendor/bin/openapi app --debug --output public/docs/api.json",
+            "php scripts/stamp-openapi-version.php public/docs/api.json"
         ],
         "openapi:test": [
-            "trap 'rm -f public/docs/check-api.json' EXIT; ./vendor/bin/openapi --output public/docs/check-api.json ./app && diff -q public/docs/check-api.json public/docs/api.json || (echo 'OpenAPI specs don’t match. Run `composer openapi` to regenerate.' && exit 1)"
+            "trap 'rm -f public/docs/check-api.json' EXIT; ./vendor/bin/openapi --output public/docs/check-api.json ./app && php scripts/stamp-openapi-version.php public/docs/check-api.json && diff -q public/docs/check-api.json public/docs/api.json || (echo 'OpenAPI specs don’t match. Run `composer openapi` to regenerate.' && exit 1)"
         ],
         "phpmd": [
             "vendor/bin/phpmd app text phpmd.xml"

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Trakli API",
-        "version": "1.0.0"
+        "version": "1.1.2"
     },
     "servers": [
         {

--- a/scripts/stamp-openapi-version.php
+++ b/scripts/stamp-openapi-version.php
@@ -1,0 +1,21 @@
+<?php
+
+// Stamps the application version from composer.json (the single source of truth)
+// into a generated OpenAPI spec, so the published docs report the current
+// version instead of the placeholder baked into the annotation. Run by the
+// "openapi" and "openapi:test" composer scripts after generation.
+
+$file = $argv[1] ?? __DIR__ . '/../public/docs/api.json';
+
+$composer = json_decode((string) file_get_contents(__DIR__ . '/../composer.json'), true);
+$version = $composer['version'] ?? '0.0.0';
+
+$json = (string) file_get_contents($file);
+$json = preg_replace_callback(
+    '/("info"\s*:\s*\{[^}]*?"version"\s*:\s*")[^"]*(")/s',
+    static fn (array $matches): string => $matches[1] . $version . $matches[2],
+    $json,
+    1
+);
+
+file_put_contents($file, $json);


### PR DESCRIPTION
The published API documentation always showed version 1.0.0, a stale placeholder, regardless of the real release. The version now comes from the project's single version field and is written into the generated spec during generation, so the docs reflect the actual current version and stay correct as it changes.