### PR TITLE
feat: Add entitlements gating seam and hosted image build

### DIFF
--- a/.github/workflows/build-hosted-image.yml
+++ b/.github/workflows/build-hosted-image.yml
@@ -1,0 +1,114 @@
+name: Build Hosted Image
+
+on:
+  workflow_call:
+    inputs:
+      plugins:
+        description: 'JSON array of plugins to bundle, e.g. [{"repo":"<org>/<plugin>","ref":"main"}]'
+        type: string
+        required: true
+      base_image:
+        description: 'Public base image to stack on'
+        type: string
+        default: 'ghcr.io/trakli/webservice:latest'
+      image_name:
+        description: 'Target hosted image'
+        type: string
+        default: 'ghcr.io/trakli/webservice-hosted'
+      tag:
+        description: 'Tag for the hosted image'
+        type: string
+        default: 'latest'
+    secrets:
+      PLUGINS_TOKEN:
+        description: 'Token with read access to the private plugin repositories'
+        required: true
+  workflow_dispatch:
+    inputs:
+      plugins:
+        description: 'JSON array of plugins to bundle'
+        type: string
+        required: true
+      base_image:
+        type: string
+        default: 'ghcr.io/trakli/webservice:latest'
+      image_name:
+        type: string
+        default: 'ghcr.io/trakli/webservice-hosted'
+      tag:
+        type: string
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout webservice
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Clone private plugins
+        env:
+          PLUGINS_TOKEN: ${{ secrets.PLUGINS_TOKEN }}
+        run: |
+          echo '${{ inputs.plugins }}' | jq -c '.[]' | while read -r plugin; do
+            repo=$(echo "$plugin" | jq -r '.repo')
+            ref=$(echo "$plugin" | jq -r '.ref // "main"')
+            dir=$(echo "$plugin" | jq -r '.id // (.repo | split("/") | .[1])')
+            git clone --depth 1 --branch "$ref" \
+              "https://x-access-token:${PLUGINS_TOKEN}@github.com/${repo}.git" \
+              "plugins/${dir}"
+            rm -rf "plugins/${dir}/.git"
+          done
+
+      - name: Install core and plugin dependencies
+        run: |
+          for d in plugins/*/; do
+            [ -f "${d}composer.json" ] || continue
+            composer config "repositories.$(basename "$d")" path "./${d%/}" --no-interaction
+          done
+          for d in plugins/*/; do
+            [ -f "${d}composer.json" ] || continue
+            name=$(php -r "echo json_decode(file_get_contents('${d}composer.json'))->name;")
+            composer require "${name}:*" --no-interaction --no-scripts --ignore-platform-reqs
+          done
+          composer install --no-dev --no-interaction --no-scripts --ignore-platform-reqs --prefer-dist
+          composer dump-autoload -o --no-interaction
+
+      - name: Prepare application environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Enable and cache bundled plugins
+        run: |
+          for id in $(ls -1 plugins); do
+            php artisan plugin:enable "$id" || true
+          done
+          php artisan plugin:cache
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push hosted image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/hosted/Dockerfile
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ inputs.base_image }}
+          tags: ${{ inputs.image_name }}:${{ inputs.tag }}

--- a/app/Contracts/Entitlements.php
+++ b/app/Contracts/Entitlements.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Gating seam for features, limits and metered usage, keyed on the resource
+ * owner so a shared owner (a future workspace or couple) is gated as a unit.
+ *
+ * The core binds a permissive default that allows everything; an external
+ * plugin may rebind it to enforce limits. No billing logic lives here.
+ */
+interface Entitlements
+{
+    public function allows(?Model $owner, string $feature): bool;
+
+    public function limit(?Model $owner, string $key): ?int;
+
+    public function remaining(?Model $owner, string $meter): int|float;
+
+    public function consume(?Model $owner, string $meter, int $amount): void;
+}

--- a/app/Http/Controllers/API/v1/CategoryController.php
+++ b/app/Http/Controllers/API/v1/CategoryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\v1;
 
+use App\Contracts\Entitlements;
 use App\Http\Controllers\API\ApiController;
 use App\Http\Traits\ApiQueryable;
 use App\Models\Category;
@@ -274,6 +275,11 @@ class CategoryController extends ApiController
         $category_exists = $user->categories()->where('name', $data['name'])->where('user_id', $user->id)->first();
         if ($category_exists) {
             return $this->failure(__('Category already exists'), 400);
+        }
+
+        $categoryLimit = app(Entitlements::class)->limit($user, 'max_categories');
+        if ($categoryLimit !== null && $user->categories()->count() >= $categoryLimit) {
+            return $this->failure(__('You have reached the maximum number of categories allowed.'), 403);
         }
 
         try {

--- a/app/Http/Controllers/API/v1/WalletController.php
+++ b/app/Http/Controllers/API/v1/WalletController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\v1;
 
+use App\Contracts\Entitlements;
 use App\Http\Controllers\API\ApiController;
 use App\Http\Traits\ApiQueryable;
 use App\Models\Wallet;
@@ -157,6 +158,11 @@ class WalletController extends ApiController
             $existingWallet->refresh();
 
             return $this->success($existingWallet, __('Wallet already exists'), 200);
+        }
+
+        $walletLimit = app(Entitlements::class)->limit($user, 'max_wallets');
+        if ($walletLimit !== null && Wallet::where('user_id', $user->id)->count() >= $walletLimit) {
+            return $this->failure(__('You have reached the maximum number of wallets allowed.'), 403);
         }
 
         try {

--- a/app/Jobs/ProcessChatMessageJob.php
+++ b/app/Jobs/ProcessChatMessageJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Contracts\Entitlements;
 use App\Models\ChatMessage;
 use App\Services\AgentRunner;
 use App\Services\AiRouter;
@@ -10,6 +11,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -43,6 +45,12 @@ class ProcessChatMessageJob implements ShouldQueue
 
         if ($userMessage === null) {
             $this->markFailed(__('No question found for this assistant message.'));
+
+            return;
+        }
+
+        if (app(Entitlements::class)->remaining($this->owner(), 'ai_tokens') <= 0) {
+            $this->answerQuotaExceeded();
 
             return;
         }
@@ -173,6 +181,39 @@ class ProcessChatMessageJob implements ShouldQueue
                 'tool_calls' => $result['tool_calls'] ?? [],
                 'usage' => $result['usage'] ?? [],
             ],
+            'completed_at' => now(),
+        ]);
+
+        $this->recordTokenUsage($result['usage'] ?? []);
+    }
+
+    /**
+     * The entity that owns this conversation: the user today, a shared
+     * workspace or couple once those land. Usage and limits are keyed on it.
+     */
+    private function owner(): ?Model
+    {
+        return $this->assistantMessage->session->owner;
+    }
+
+    /**
+     * @param  array{prompt_tokens?: int, completion_tokens?: int}  $usage
+     */
+    private function recordTokenUsage(array $usage): void
+    {
+        $tokens = (int) ($usage['prompt_tokens'] ?? 0) + (int) ($usage['completion_tokens'] ?? 0);
+
+        if ($tokens > 0) {
+            app(Entitlements::class)->consume($this->owner(), 'ai_tokens', $tokens);
+        }
+    }
+
+    private function answerQuotaExceeded(): void
+    {
+        $this->assistantMessage->update([
+            'status' => ChatMessage::STATUS_COMPLETED,
+            'content' => __('You have reached your AI usage limit for this period.'),
+            'result' => ['source' => 'quota_exceeded', 'format_type' => 'raw', 'rows' => []],
             'completed_at' => now(),
         ]);
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace App\Providers;
 
+use App\Contracts\Entitlements;
 use App\Contracts\OwnerResolver;
 use App\Services\DocumentProcessorManager;
 use App\Services\DocumentProcessors\CsvProcessor;
 use App\Services\DocumentProcessors\RemoteDocumentProcessor;
 use App\Services\SchemaConformance\SchemaConformanceService;
+use App\Support\AllowAllEntitlements;
 use App\Support\UserOwnerResolver;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Support\Carbon;
@@ -26,6 +28,8 @@ class AppServiceProvider extends ServiceProvider
         $this->app->register(PluginServiceProvider::class);
 
         $this->app->singleton(OwnerResolver::class, UserOwnerResolver::class);
+
+        $this->app->singleton(Entitlements::class, AllowAllEntitlements::class);
 
         $this->app->singleton(DocumentProcessorManager::class, function ($app) {
             $manager = new DocumentProcessorManager();

--- a/app/Support/AllowAllEntitlements.php
+++ b/app/Support/AllowAllEntitlements.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Support;
+
+use App\Contracts\Entitlements;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Default Entitlements: grants every feature, imposes no limit, never meters.
+ * Keeps the open core free and self-hostable until a plugin overrides it.
+ */
+class AllowAllEntitlements implements Entitlements
+{
+    public function allows(?Model $owner, string $feature): bool
+    {
+        return true;
+    }
+
+    public function limit(?Model $owner, string $key): ?int
+    {
+        return null;
+    }
+
+    public function remaining(?Model $owner, string $meter): int|float
+    {
+        return INF;
+    }
+
+    public function consume(?Model $owner, string $meter, int $amount): void
+    {
+    }
+}

--- a/docker/hosted/Dockerfile
+++ b/docker/hosted/Dockerfile
@@ -1,0 +1,22 @@
+# Trakli hosted image: the public base plus bundled private plugins,
+# enabled and cached so paid features are available out of the box.
+#
+# The build context is prepared by the hosted-image workflow on the runner
+# (private plugins cloned into plugins/, their dependencies installed into
+# vendor/, and the plugin cache regenerated) before this image is built.
+ARG BASE_IMAGE=ghcr.io/trakli/webservice:latest
+
+FROM ${BASE_IMAGE}
+
+LABEL org.opencontainers.image.source=https://github.com/trakli/webservice
+LABEL org.opencontainers.image.description="Trakli hosted API webservice"
+LABEL org.opencontainers.image.vendor="WhileSmart LLC"
+
+USER root
+
+COPY --chown=www-data:www-data plugins/ /var/www/html/plugins/
+COPY --chown=www-data:www-data vendor/ /var/www/html/vendor/
+COPY --chown=www-data:www-data bootstrap/cache/ /var/www/html/bootstrap/cache/
+COPY --chown=www-data:www-data composer.json composer.lock /var/www/html/
+
+USER www-data

--- a/tests/Feature/EntitlementsTest.php
+++ b/tests/Feature/EntitlementsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Contracts\Entitlements;
+use App\Jobs\ProcessChatMessageJob;
+use App\Models\ChatMessage;
+use App\Models\ChatSession;
+use App\Models\User;
+use App\Services\AgentRunner;
+use App\Services\AiRouter;
+use App\Services\AiService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class EntitlementsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_default_binding_allows_unlimited_wallets(): void
+    {
+        $resolved = $this->app->make(Entitlements::class);
+
+        $this->assertNull($resolved->limit($this->user, 'max_wallets'));
+        $this->assertTrue($resolved->allows($this->user, 'plaid'));
+        $this->assertEquals(INF, $resolved->remaining($this->user, 'ai_tokens'));
+    }
+
+    public function test_wallet_create_blocked_when_over_limit(): void
+    {
+        $this->bindLimit('max_wallets', 0);
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/wallets', [
+                'name' => 'My Wallet',
+                'type' => 'bank',
+                'currency' => 'XAF',
+                'balance' => 0,
+            ])
+            ->assertStatus(403);
+
+        $this->assertEquals(0, $this->user->wallets()->count());
+    }
+
+    public function test_category_create_blocked_when_over_limit(): void
+    {
+        $this->bindLimit('max_categories', 0);
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/categories', [
+                'type' => 'expense',
+                'name' => 'Groceries',
+            ])
+            ->assertStatus(403);
+
+        $this->assertEquals(0, $this->user->categories()->count());
+    }
+
+    public function test_ai_turn_blocked_when_token_allowance_exhausted(): void
+    {
+        $fake = Mockery::mock(Entitlements::class);
+        $fake->shouldReceive('remaining')->with(Mockery::any(), 'ai_tokens')->andReturn(0);
+        $fake->shouldNotReceive('consume');
+        $this->app->instance(Entitlements::class, $fake);
+
+        [$assistant] = $this->makeTurn('log 20 for coffee');
+
+        (new ProcessChatMessageJob($assistant))->handle(
+            Mockery::mock(AiService::class),
+            Mockery::mock(AiRouter::class),
+            Mockery::mock(AgentRunner::class),
+        );
+
+        $assistant->refresh();
+        $this->assertEquals(ChatMessage::STATUS_COMPLETED, $assistant->status);
+        $this->assertEquals('quota_exceeded', $assistant->result['source']);
+    }
+
+    public function test_agent_turn_consumes_summed_tokens(): void
+    {
+        $fake = Mockery::mock(Entitlements::class);
+        $fake->shouldReceive('remaining')->with(Mockery::any(), 'ai_tokens')->andReturn(INF);
+        $fake->shouldReceive('consume')->once()->with(Mockery::any(), 'ai_tokens', 15);
+        $this->app->instance(Entitlements::class, $fake);
+
+        [$assistant] = $this->makeTurn('log 20 for coffee');
+
+        $router = Mockery::mock(AiRouter::class);
+        $router->shouldReceive('classify')->once()->andReturn(AiRouter::ROUTE_AGENT);
+        $router->shouldReceive('generateTitle')->andReturn('Log coffee');
+
+        $agent = Mockery::mock(AgentRunner::class);
+        $agent->shouldReceive('run')->once()->andReturn([
+            'ok' => true,
+            'text' => 'Done.',
+            'blocks' => [['type' => 'markdown', 'text' => 'Done.']],
+            'tool_calls' => [['name' => 'record_transaction', 'arguments' => []]],
+            'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5],
+        ]);
+
+        (new ProcessChatMessageJob($assistant))->handle(Mockery::mock(AiService::class), $router, $agent);
+
+        $assistant->refresh();
+        $this->assertEquals(15, ($assistant->result['usage']['prompt_tokens'] ?? 0)
+            + ($assistant->result['usage']['completion_tokens'] ?? 0));
+    }
+
+    private function bindLimit(string $key, int $value): void
+    {
+        $fake = Mockery::mock(Entitlements::class);
+        $fake->shouldReceive('limit')->with(Mockery::any(), $key)->andReturn($value);
+        $fake->shouldReceive('limit')->andReturn(null);
+        $fake->shouldReceive('allows')->andReturn(true);
+        $fake->shouldReceive('remaining')->andReturn(INF);
+        $fake->shouldReceive('consume');
+        $this->app->instance(Entitlements::class, $fake);
+    }
+
+    private function makeTurn(string $question): array
+    {
+        $session = ChatSession::create([
+            'owner_type' => $this->user->getMorphClass(),
+            'owner_id' => $this->user->getKey(),
+        ]);
+        $user = $session->messages()->create([
+            'user_id' => $this->user->id,
+            'role' => ChatMessage::ROLE_USER,
+            'content' => $question,
+        ]);
+        $assistant = $session->messages()->create([
+            'role' => ChatMessage::ROLE_ASSISTANT,
+            'status' => ChatMessage::STATUS_PENDING,
+        ]);
+
+        return [$assistant, $user];
+    }
+}


### PR DESCRIPTION
Adds a generic gating seam to the core (#260) and a reusable workflow that builds the private hosted image (#261), so paid integrations can be gated and billed by a separate plugin without any subscription logic or paid source in the open core.

## Core: Entitlements seam (#260)
- New billing-free contract covering features, numeric limits, and metered usage.
- Permissive allow-all default, so the open core stays free and self-hostable; a plugin rebinds it to enforce limits.
- Keyed on the resource owner rather than the user, so a future shared owner (workspace/couple) is gated as one unit.
- Wired in: AI chat stops a turn when its token allowance is exhausted and records tokens consumed; wallet and category creation respect configured caps.
- No Stripe, Cashier, plan, price, or billing table code in core.

## Hosted image build (#261)
- Reusable workflow stacks private plugins onto the public base image to produce a private hosted image.
- Each plugin is fetched, installed, enabled, and cached; the public base and its source stay free of any paid code.

## Tests
- New `EntitlementsTest`: default allow-all, wallet/category limit blocks, AI quota block, token accounting.
- Full suite green (620 passed); lint and sniffs pass.

## Notes
- The hosted-image workflow runs only when called with a plugin list, so it is not exercised by this repo's CI alone.

Closes #260
Closes #261