### PR TITLE
feat: Add processor priority and integrations registry

### DIFF
--- a/app/Contracts/Integration.php
+++ b/app/Contracts/Integration.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * Declarative descriptor for an integration (bank sync, document analytics,
+ * and so on). Plugins register one with the IntegrationRegistry so core can
+ * list what is installed without knowing any specific vendor. Behaviour
+ * (connect, sync) stays with the plugin; this layer is metadata only.
+ */
+interface Integration
+{
+    public function key(): string;
+
+    public function name(): string;
+
+    public function description(): ?string;
+
+    public function category(): string;
+
+    public function icon(): ?string;
+
+    /**
+     * Entitlement feature key this integration is gated by, or null when free.
+     */
+    public function featureKey(): ?string;
+
+    /**
+     * Whether the operator has supplied the configuration this integration
+     * needs to run (API keys, service URL, and so on).
+     */
+    public function isConfigured(): bool;
+}

--- a/app/Http/Controllers/API/v1/IntegrationController.php
+++ b/app/Http/Controllers/API/v1/IntegrationController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Contracts\Integration;
+use App\Http\Controllers\API\ApiController;
+use App\Services\IntegrationRegistry;
+use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
+
+#[OA\Tag(name: 'Integration', description: 'Installed integrations')]
+class IntegrationController extends ApiController
+{
+    public function __construct(private IntegrationRegistry $registry)
+    {
+    }
+
+    #[OA\Get(
+        path: '/integrations',
+        summary: 'List installed integrations',
+        tags: ['Integration'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Successful response',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            property: 'data',
+                            type: 'array',
+                            items: new OA\Items(
+                                properties: [
+                                    new OA\Property(property: 'key', type: 'string'),
+                                    new OA\Property(property: 'name', type: 'string'),
+                                    new OA\Property(property: 'description', type: 'string', nullable: true),
+                                    new OA\Property(property: 'category', type: 'string'),
+                                    new OA\Property(property: 'icon', type: 'string', nullable: true),
+                                    new OA\Property(property: 'feature_key', type: 'string', nullable: true),
+                                    new OA\Property(property: 'configured', type: 'boolean'),
+                                ],
+                                type: 'object'
+                            )
+                        ),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(response: 401, description: 'Unauthorized'),
+        ]
+    )]
+    public function index(): JsonResponse
+    {
+        $data = array_map(fn (Integration $integration) => [
+            'key' => $integration->key(),
+            'name' => $integration->name(),
+            'description' => $integration->description(),
+            'category' => $integration->category(),
+            'icon' => $integration->icon(),
+            'feature_key' => $integration->featureKey(),
+            'configured' => $integration->isConfigured(),
+        ], $this->registry->all());
+
+        return $this->success($data);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Contracts\OwnerResolver;
 use App\Services\DocumentProcessorManager;
 use App\Services\DocumentProcessors\CsvProcessor;
 use App\Services\DocumentProcessors\RemoteDocumentProcessor;
+use App\Services\IntegrationRegistry;
 use App\Services\SchemaConformance\SchemaConformanceService;
 use App\Support\AllowAllEntitlements;
 use App\Support\UserOwnerResolver;
@@ -30,6 +31,8 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(OwnerResolver::class, UserOwnerResolver::class);
 
         $this->app->singleton(Entitlements::class, AllowAllEntitlements::class);
+
+        $this->app->singleton(IntegrationRegistry::class);
 
         $this->app->singleton(DocumentProcessorManager::class, function ($app) {
             $manager = new DocumentProcessorManager();

--- a/app/Services/DocumentProcessorManager.php
+++ b/app/Services/DocumentProcessorManager.php
@@ -7,17 +7,24 @@ use RuntimeException;
 
 class DocumentProcessorManager
 {
-    /** @var DocumentProcessor[] */
+    /** @var array<int, array{processor: DocumentProcessor, priority: int, seq: int}> */
     private array $processors = [];
 
-    public function register(DocumentProcessor $processor): void
+    private int $seq = 0;
+
+    /**
+     * Higher priority wins; equal priority falls back to registration order, so
+     * a plugin can override a configured engine for a type by registering with
+     * a priority above the defaults.
+     */
+    public function register(DocumentProcessor $processor, int $priority = 0): void
     {
-        $this->processors[] = $processor;
+        $this->processors[] = ['processor' => $processor, 'priority' => $priority, 'seq' => $this->seq++];
     }
 
     public function canHandle(string $mimeType, string $extension): bool
     {
-        foreach ($this->processors as $processor) {
+        foreach ($this->ordered() as $processor) {
             if ($processor->supports($mimeType, $extension)) {
                 return true;
             }
@@ -31,12 +38,24 @@ class DocumentProcessorManager
      */
     public function getProcessor(string $mimeType, string $extension): DocumentProcessor
     {
-        foreach ($this->processors as $processor) {
+        foreach ($this->ordered() as $processor) {
             if ($processor->supports($mimeType, $extension)) {
                 return $processor;
             }
         }
 
         throw new RuntimeException("No document processor available for type: {$mimeType} ({$extension})");
+    }
+
+    /**
+     * @return DocumentProcessor[]
+     */
+    private function ordered(): array
+    {
+        $entries = $this->processors;
+
+        usort($entries, fn ($left, $right) => $right['priority'] <=> $left['priority'] ?: $left['seq'] <=> $right['seq']);
+
+        return array_map(fn ($entry) => $entry['processor'], $entries);
     }
 }

--- a/app/Services/IntegrationRegistry.php
+++ b/app/Services/IntegrationRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Integration;
+
+class IntegrationRegistry
+{
+    /** @var array<string, Integration> */
+    private array $integrations = [];
+
+    public function register(Integration $integration): void
+    {
+        $this->integrations[$integration->key()] = $integration;
+    }
+
+    /**
+     * @return Integration[]
+     */
+    public function all(): array
+    {
+        return array_values($this->integrations);
+    }
+
+    public function get(string $key): ?Integration
+    {
+        return $this->integrations[$key] ?? null;
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->integrations[$key]);
+    }
+}

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -37,8 +37,8 @@ Each plugin must have a `plugin.json` file in its root directory with the follow
     "provider": "Namespace\\To\\ServiceProvider",
     "enabled": true,
     "requires": {
-        "php": ">=7.4",
-        "laravel/framework": "^8.0"
+        "php": ">=8.2",
+        "laravel/framework": "^11.0"
     }
 }
 ```
@@ -99,6 +99,48 @@ php artisan plugin disable plugin-name
 3. Create your service provider in `src/`
 4. Add your routes, views, and other resources
 5. Run `php artisan plugin discover` to register your plugin
+
+## Core Extension Points
+
+Beyond routes and migrations, the core exposes contracts a plugin can hook into. Resolve them from the container inside your service provider's `boot()`.
+
+### Feature gating (Entitlements)
+
+`App\Contracts\Entitlements` decides whether an owner may use a feature, what limits apply, and how much of a metered allowance remains. It is keyed on the resource owner (a user today, a shared owner later), not the user directly. The core binds a permissive default that allows everything; a billing plugin may rebind it to enforce a plan.
+
+Gate a paid route or action:
+
+```php
+if (! app(\App\Contracts\Entitlements::class)->allows($owner, 'your-feature')) {
+    abort(403);
+}
+```
+
+Feature keys are plain strings; the billing plugin maps them to plans. With no override, the default allows everything, so the open core stays free and self-hostable.
+
+### Integration registry
+
+Register a descriptor so the integration appears in `GET /api/v1/integrations`:
+
+```php
+app(\App\Services\IntegrationRegistry::class)->register($yourIntegration);
+```
+
+where `$yourIntegration` implements `App\Contracts\Integration` (`key`, `name`, `category`, `featureKey`, `isConfigured`, and so on). This layer is metadata only; connect and sync behaviour stays in the plugin.
+
+### Document processors
+
+Handle a document type, or take precedence over the configured engine, by registering an `App\Contracts\DocumentProcessor` with a priority:
+
+```php
+app(\App\Services\DocumentProcessorManager::class)->register($yourProcessor, priority: 100);
+```
+
+The highest-priority processor whose `supports($mimeType, $extension)` returns true wins; equal priority keeps registration order.
+
+## Paid and Private Plugins
+
+Private, paid plugins live in their own repositories and never ship in the open image. A reusable workflow stacks them onto the public base image to produce a private hosted image with the plugins enabled and cached. Gate their features through `Entitlements` so the same code path stays inert on the open core.
 
 ## Best Practices
 

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2134,6 +2134,64 @@
                 }
             }
         },
+        "/integrations": {
+            "get": {
+                "tags": [
+                    "Integration"
+                ],
+                "summary": "List installed integrations",
+                "operationId": "9e3b3dbcc15c25ecbe63d2597b47d9e1",
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
+                                                    "category": {
+                                                        "type": "string"
+                                                    },
+                                                    "icon": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
+                                                    "feature_key": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
+                                                    "configured": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                }
+            }
+        },
         "/notifications": {
             "get": {
                 "tags": [
@@ -6157,6 +6215,10 @@
         {
             "name": "Files",
             "description": "Endpoints for accessing files"
+        },
+        {
+            "name": "Integration",
+            "description": "Installed integrations"
         },
         {
             "name": "Notifications",

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\API\v1\CategoryController;
 use App\Http\Controllers\API\v1\FileController;
 use App\Http\Controllers\API\v1\GroupController;
 use App\Http\Controllers\API\v1\ImportController;
+use App\Http\Controllers\API\v1\IntegrationController;
 use App\Http\Controllers\API\v1\NotificationController;
 use App\Http\Controllers\API\v1\PartyController;
 use App\Http\Controllers\API\v1\ReminderController;
@@ -47,6 +48,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['auth:sanctum']], function () {
 
         Route::get('stats', [StatsController::class, 'index']);
     });
+    Route::get('integrations', [IntegrationController::class, 'index']);
     Route::apiResource('transactions', TransactionController::class);
     Route::post('/transactions/{id}/files', [TransactionController::class, 'uploadFiles']);
     Route::delete('/transactions/{id}/files/{file_id}', [TransactionController::class, 'deleteFiles']);

--- a/tests/Feature/IntegrationsTest.php
+++ b/tests/Feature/IntegrationsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Contracts\Integration;
+use App\Models\User;
+use App\Services\IntegrationRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IntegrationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lists_registered_integrations(): void
+    {
+        app(IntegrationRegistry::class)->register($this->fakeIntegration());
+
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/integrations')
+            ->assertOk()
+            ->assertJsonPath('data.0.key', 'plaid')
+            ->assertJsonPath('data.0.category', 'bank-sync')
+            ->assertJsonPath('data.0.feature_key', 'plaid')
+            ->assertJsonPath('data.0.configured', true);
+    }
+
+    public function test_returns_empty_list_when_nothing_registered(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/integrations')
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/integrations')->assertUnauthorized();
+    }
+
+    private function fakeIntegration(): Integration
+    {
+        return new class () implements Integration {
+            public function key(): string
+            {
+                return 'plaid';
+            }
+
+            public function name(): string
+            {
+                return 'Plaid';
+            }
+
+            public function description(): ?string
+            {
+                return 'Bank account sync';
+            }
+
+            public function category(): string
+            {
+                return 'bank-sync';
+            }
+
+            public function icon(): ?string
+            {
+                return null;
+            }
+
+            public function featureKey(): ?string
+            {
+                return 'plaid';
+            }
+
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/tests/Unit/Services/DocumentProcessorManagerTest.php
+++ b/tests/Unit/Services/DocumentProcessorManagerTest.php
@@ -79,6 +79,28 @@ class DocumentProcessorManagerTest extends TestCase
         $this->assertSame($firstProcessor, $this->manager->getProcessor('text/csv', 'csv'));
     }
 
+    public function test_higher_priority_wins_over_earlier_registration(): void
+    {
+        $default = $this->createMockProcessor('application/pdf', 'pdf');
+        $preferred = $this->createMockProcessor('application/pdf', 'pdf');
+
+        $this->manager->register($default);
+        $this->manager->register($preferred, 100);
+
+        $this->assertSame($preferred, $this->manager->getProcessor('application/pdf', 'pdf'));
+    }
+
+    public function test_equal_priority_preserves_registration_order(): void
+    {
+        $first = $this->createMockProcessor('text/csv', 'csv');
+        $second = $this->createMockProcessor('text/csv', 'csv');
+
+        $this->manager->register($first, 5);
+        $this->manager->register($second, 5);
+
+        $this->assertSame($first, $this->manager->getProcessor('text/csv', 'csv'));
+    }
+
     private function createMockProcessor(string $supportedMime, string $supportedExt): DocumentProcessor
     {
         $processor = $this->createMock(DocumentProcessor::class);

--- a/tests/Unit/Services/IntegrationRegistryTest.php
+++ b/tests/Unit/Services/IntegrationRegistryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Contracts\Integration;
+use App\Services\IntegrationRegistry;
+use PHPUnit\Framework\TestCase;
+
+class IntegrationRegistryTest extends TestCase
+{
+    private IntegrationRegistry $registry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->registry = new IntegrationRegistry();
+    }
+
+    public function test_registers_and_lists_integrations(): void
+    {
+        $this->registry->register($this->fakeIntegration('plaid'));
+        $this->registry->register($this->fakeIntegration('kreuzberg'));
+
+        $keys = array_map(fn (Integration $i) => $i->key(), $this->registry->all());
+
+        $this->assertEqualsCanonicalizing(['plaid', 'kreuzberg'], $keys);
+    }
+
+    public function test_get_and_has_resolve_by_key(): void
+    {
+        $plaid = $this->fakeIntegration('plaid');
+        $this->registry->register($plaid);
+
+        $this->assertTrue($this->registry->has('plaid'));
+        $this->assertSame($plaid, $this->registry->get('plaid'));
+        $this->assertFalse($this->registry->has('unknown'));
+        $this->assertNull($this->registry->get('unknown'));
+    }
+
+    public function test_registering_same_key_replaces_previous(): void
+    {
+        $this->registry->register($this->fakeIntegration('plaid'));
+        $replacement = $this->fakeIntegration('plaid');
+        $this->registry->register($replacement);
+
+        $this->assertCount(1, $this->registry->all());
+        $this->assertSame($replacement, $this->registry->get('plaid'));
+    }
+
+    private function fakeIntegration(string $key): Integration
+    {
+        $integration = $this->createMock(Integration::class);
+        $integration->method('key')->willReturn($key);
+
+        return $integration;
+    }
+}


### PR DESCRIPTION
Two core seams that let integrations plug in cleanly, in support of paid integrations like Plaid and Kreuzberg.

## Document processor priority
- `DocumentProcessorManager::register()` now takes a priority; the highest-priority supporting processor wins.
- Equal priority keeps registration order, so existing selection is unchanged.
- Lets an installed plugin take precedence over the configured remote engine for a file type, instead of losing to whatever registered first.

## Integrations registry
- New `Integration` descriptor contract (key, name, category, gating feature key, configured flag), an `IntegrationRegistry`, and `GET /api/v1/integrations`.
- Lets the app present installed integrations uniformly without knowing any specific provider.
- Declarative only: connect and sync behaviour stays in each plugin. An open install lists nothing until a plugin registers one.

## Tests
- Priority selection and equal-priority ordering.
- Registry register / get / has / replace.
- Endpoint lists registered integrations, returns empty by default, and requires auth.

## Notes
- Builds on the merged Entitlements seam: the descriptor's `feature_key` ties an integration to its gate. Entitlement-aware listing is a follow-up.
- OpenAPI doc regenerated for the new endpoint.