### PR TITLE
feat: Add intent tagging, financial position, and asset holdings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+Conventions for keeping the AI assistant in sync with the data model. The
+assistant can only see and act on what we expose to it, so adding a model
+without tools leaves a feature the AI is blind to.
+
+## Rule: new user-facing models ship with AI access
+
+When you add an Eloquent model / table that holds user data (or a meaningful new
+field on one), in the same change also do the following.
+
+### 1. Read tool
+
+Add a read tool under `app/Ai/Tools/Read/` so the assistant can see the data,
+scoped to the authenticated user (`$context->user`). Mirror
+`app/Ai/Tools/Read/ListWalletsTool.php` (or `ListHoldingsTool.php`): extend
+`Whilesmart\Agents\Tools\AbstractTool`, `permission()` returns
+`ToolPermission::READ`, return a plain array.
+
+### 2. Write tool (when users create/change it conversationally)
+
+If users would naturally say "add a ...", add a write tool under
+`app/Ai/Tools/Write/` extending `AbstractWriteTool`. Write tools only *propose*
+an action the user confirms; execution goes through `ProposedActionExecutor`
+(add the new `*.create` action type there). Mirror
+`app/Ai/Tools/Write/RecordTransactionTool.php`.
+
+### 3. Register the tool
+
+Add the class to the `tools` array in `config/agents.php`. A tool that isn't
+listed there is never offered to the assistant.
+
+### 4. smartql.yml (if the table should be queryable)
+
+If the assistant should be able to query the table ad hoc (totals, filters,
+joins), add it to `smartql.yml` under `semantic_layer.entities`: the real table
+name, a description, `aliases` the user might say, and the columns with types and
+descriptions. Add new *columns* on existing tables too (e.g. a new enum field),
+and any `relationships`. The SmartQL tool can only reach declared tables/columns.
+
+### 5. Analytics (when relevant)
+
+If the model feeds a headline number, expose it through a `GetStatsTool` section
+(`app/Ai/Tools/Read/GetStatsTool.php` + `StatsService`) rather than expecting the
+assistant to compute it.
+
+## Reference: holdings
+
+`whilesmart/eloquent-holdings` is the worked example: `ListHoldingsTool`
+(read), the `holdings` entity in `smartql.yml`, the `position` section in
+`GetStatsTool`/`StatsService` for net worth. A record/write tool for holdings is
+the outstanding piece and should follow the same pattern.
+
+## Checklist for a new model
+
+- [ ] Read tool in `app/Ai/Tools/Read/`, user-scoped
+- [ ] Write tool in `app/Ai/Tools/Write/` (+ `ProposedActionExecutor` action) if user-created
+- [ ] Registered in `config/agents.php`
+- [ ] `smartql.yml` entity / new columns / relationships
+- [ ] Stats section if it drives a headline figure
+- [ ] Tests covering the tool through the user boundary

--- a/app/Ai/Tools/Read/GetStatsTool.php
+++ b/app/Ai/Tools/Read/GetStatsTool.php
@@ -26,14 +26,19 @@ class GetStatsTool extends AbstractTool
     public function description(): string
     {
         return 'Get pre-computed financial analytics for the user: balances, income, expenses, '
-            . 'savings rate, top categories, parties and cash flow. Choose a section. Returns '
-            . 'authoritative numbers; never invent figures.';
+            . 'savings rate, top categories, parties, cash flow, and financial position '
+            . '(net worth, earned income vs discretionary spend, loans/debt, investments). '
+            . 'Choose a section. Returns authoritative numbers; never invent figures.';
     }
 
     public function parameters(): array
     {
         return [
-            ParameterSpec::enum('section', 'Which analytics section to compute.', ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow']),
+            ParameterSpec::enum(
+                'section',
+                'Which analytics section to compute. "position" returns net worth and the intent-based money-in/out breakdown.',
+                ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow', 'position']
+            ),
             ParameterSpec::enum('period', 'Bucketing period for trends.', ['day', 'week', 'month', 'year'], required: false),
             ParameterSpec::string('start_date', 'Window start (YYYY-MM-DD). Defaults to 30 days ago.', required: false),
             ParameterSpec::string('end_date', 'Window end (YYYY-MM-DD). Defaults to today.', required: false),

--- a/app/Ai/Tools/Read/ListHoldingsTool.php
+++ b/app/Ai/Tools/Read/ListHoldingsTool.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Ai\Tools\Read;
+
+use App\Models\User;
+use Whilesmart\Agents\Enums\ToolPermission;
+use Whilesmart\Agents\Tools\AbstractTool;
+use Whilesmart\Agents\ValueObjects\ToolContext;
+use Whilesmart\Holdings\Models\Holding;
+
+class ListHoldingsTool extends AbstractTool
+{
+    public function name(): string
+    {
+        return 'list_holdings';
+    }
+
+    public function description(): string
+    {
+        return 'List the user\'s asset holdings (id, name, symbol, quantity, currency, unit price, '
+            . 'value, price source). Use for questions about owned assets, crypto, stocks or net worth.';
+    }
+
+    public function permission(): ToolPermission
+    {
+        return ToolPermission::READ;
+    }
+
+    /** @SuppressWarnings(PHPMD.UnusedFormalParameter) */
+    public function handle(array $arguments, ToolContext $context): string|array
+    {
+        $user = $context->user;
+        if ($user === null) {
+            return ['error' => 'No authenticated user in context.'];
+        }
+
+        $holdings = Holding::where('owner_type', User::class)
+            ->where('owner_id', $user->id)
+            ->get();
+
+        return [
+            'holdings' => $holdings->map(fn (Holding $h) => [
+                'id' => $h->id,
+                'name' => $h->name,
+                'symbol' => $h->symbol,
+                'quantity' => (float) $h->quantity,
+                'currency' => $h->currency,
+                'unit_price' => (float) $h->unit_price,
+                'value' => $h->value,
+                'price_source' => $h->price_source?->value,
+            ])->all(),
+        ];
+    }
+}

--- a/app/Ai/Tools/Write/RecordTransactionTool.php
+++ b/app/Ai/Tools/Write/RecordTransactionTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Ai\Tools\Write;
 
+use App\Enums\TransactionIntent;
 use InvalidArgumentException;
 use Whilesmart\Agents\ValueObjects\ParameterSpec;
 use Whilesmart\Agents\ValueObjects\ToolContext;
@@ -36,6 +37,15 @@ class RecordTransactionTool extends AbstractWriteTool
         return [
             ParameterSpec::number('amount', 'The transaction amount, a positive number.'),
             ParameterSpec::enum('type', 'Whether money came in or went out.', ['income', 'expense']),
+            ParameterSpec::enum(
+                'intent',
+                'What the money movement really is. Default "regular" for ordinary earnings or spending. '
+                . 'Use loan_received/debt_owed (income) or loan_repayment/debt_settled (expense) for borrowing, '
+                . 'investment_buy (expense) / investment_return (income) for investments, and gift (income) for gifts. '
+                . 'Only set this when the user clearly indicates it.',
+                TransactionIntent::values(),
+                required: false
+            ),
             ParameterSpec::number('wallet_id', 'The id of the wallet (preferred; get it from list_wallets).', required: false),
             ParameterSpec::string('wallet_name', 'The exact wallet name, if you do not have its id.', required: false),
             ParameterSpec::string('description', 'Free text describing the purchase, e.g. "coffee". This is NOT a category.', required: false),
@@ -60,6 +70,11 @@ class RecordTransactionTool extends AbstractWriteTool
             throw new InvalidArgumentException('Type must be income or expense.');
         }
 
+        $intent = $arguments['intent'] ?? null;
+        if ($intent !== null && ! in_array($intent, TransactionIntent::values(), true)) {
+            throw new InvalidArgumentException('Unknown transaction intent.');
+        }
+
         $walletId = $this->resolveWalletId($user, $arguments);
         $categoryIds = $this->resolveCategoryIds($user, (array) ($arguments['category_names'] ?? []));
         $partyId = $this->resolvePartyId($user, $arguments);
@@ -67,6 +82,7 @@ class RecordTransactionTool extends AbstractWriteTool
         return array_filter([
             'amount' => $amount,
             'type' => $type,
+            'intent' => $intent,
             'wallet_id' => $walletId,
             'party_id' => $partyId,
             'description' => $arguments['description'] ?? null,
@@ -102,8 +118,18 @@ class RecordTransactionTool extends AbstractWriteTool
             ? optional($user->parties()->find($partyId))->name
             : null;
 
+        $intent = (string) ($payload['intent'] ?? 'regular');
+
         return [
             ['key' => 'type', 'label' => 'Type', 'type' => 'enum', 'value' => $type, 'display' => ucfirst($type), 'options' => ['income', 'expense']],
+            [
+                'key' => 'intent',
+                'label' => 'Intent',
+                'type' => 'enum',
+                'value' => $intent,
+                'display' => ucwords(str_replace('_', ' ', $intent)),
+                'options' => TransactionIntent::values(),
+            ],
             ['key' => 'amount', 'label' => 'Amount', 'type' => 'number', 'value' => $payload['amount'] ?? 0, 'display' => (string) ($payload['amount'] ?? '')],
             ['key' => 'wallet_id', 'label' => 'Wallet', 'type' => 'wallet', 'value' => $walletId, 'display' => $walletName ?? ('#' . $walletId)],
             ['key' => 'party_id', 'label' => 'Party', 'type' => 'party', 'value' => $partyId, 'display' => $partyName ?? ($partyId ? '#' . $partyId : '')],

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,10 @@ class Kernel extends ConsoleKernel
         $schedule->command('budgets:send-digests')
             ->weeklyOn(1, '08:00')
             ->withoutOverlapping();
+
+        $schedule->command('holdings:reprice')
+            ->dailyAt('06:00')
+            ->withoutOverlapping();
     }
 
     /**

--- a/app/Enums/TransactionIntent.php
+++ b/app/Enums/TransactionIntent.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Enums;
+
+enum TransactionIntent: string
+{
+    case REGULAR = 'regular';
+    case LOAN_RECEIVED = 'loan_received';
+    case LOAN_REPAYMENT = 'loan_repayment';
+    case DEBT_OWED = 'debt_owed';
+    case DEBT_SETTLED = 'debt_settled';
+    case INVESTMENT_BUY = 'investment_buy';
+    case INVESTMENT_RETURN = 'investment_return';
+    case GIFT = 'gift';
+
+    /**
+     * @return string[]
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $case) => $case->value, self::cases());
+    }
+
+    public function bucket(): string
+    {
+        return match ($this) {
+            self::REGULAR => 'regular',
+            self::LOAN_RECEIVED, self::LOAN_REPAYMENT => 'loan',
+            self::DEBT_OWED, self::DEBT_SETTLED => 'debt',
+            self::INVESTMENT_BUY, self::INVESTMENT_RETURN => 'investment',
+            self::GIFT => 'gift',
+        };
+    }
+
+    /**
+     * +1 when the movement raises net worth (money or asset in), -1 when it
+     * lowers it (money or asset out).
+     */
+    public function sign(): int
+    {
+        return match ($this) {
+            self::LOAN_REPAYMENT, self::DEBT_SETTLED, self::INVESTMENT_BUY => -1,
+            default => 1,
+        };
+    }
+
+    public function isRegular(): bool
+    {
+        return $this === self::REGULAR;
+    }
+
+    public function isLoanOrDebt(): bool
+    {
+        return in_array($this->bucket(), ['loan', 'debt'], true);
+    }
+
+    public function isInvestment(): bool
+    {
+        return $this->bucket() === 'investment';
+    }
+}

--- a/app/Holdings/CoingeckoPriceProvider.php
+++ b/app/Holdings/CoingeckoPriceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Holdings;
+
+use App\Services\AssetPriceService;
+use Whilesmart\Holdings\Contracts\HoldingPriceProvider;
+
+/**
+ * Resolves crypto prices through CoinGecko; non-crypto assets return no price.
+ */
+class CoingeckoPriceProvider implements HoldingPriceProvider
+{
+    public function __construct(private readonly AssetPriceService $assetPrices)
+    {
+    }
+
+    public function prices(string $provider, array $externalRefs, string $currency): array
+    {
+        if ($provider !== 'coingecko') {
+            return [];
+        }
+
+        return $this->assetPrices->fetchPrices($externalRefs, $currency);
+    }
+}

--- a/app/Holdings/UserOwnerAuthorizer.php
+++ b/app/Holdings/UserOwnerAuthorizer.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Holdings;
+
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
+use Whilesmart\OwnerAccess\Contracts\OwnerAuthorizer;
+
+/**
+ * Scopes owner-access records to the authenticated user: a user may only reach
+ * records whose owner is their own User.
+ */
+class UserOwnerAuthorizer implements OwnerAuthorizer
+{
+    public function authorize(?Authenticatable $user, string $ownerType, mixed $ownerId): bool
+    {
+        return $user !== null
+            && $ownerType === User::class
+            && (int) $ownerId === (int) $user->getAuthIdentifier();
+    }
+
+    public function scope(
+        Builder $query,
+        ?Authenticatable $user,
+        string $ownerTypeColumn = 'owner_type',
+        string $ownerIdColumn = 'owner_id',
+    ): Builder {
+        if ($user === null) {
+            return $query->whereRaw('0 = 1');
+        }
+
+        return $query->where($ownerTypeColumn, User::class)
+            ->where($ownerIdColumn, $user->getAuthIdentifier());
+    }
+}

--- a/app/Http/Controllers/API/v1/AssetPriceController.php
+++ b/app/Http/Controllers/API/v1/AssetPriceController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Http\Controllers\API\ApiController;
+use App\Services\AssetPriceService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+
+class AssetPriceController extends ApiController
+{
+    public function __construct(protected AssetPriceService $assetPrices)
+    {
+    }
+
+    #[OA\Get(path: '/asset-prices/search', summary: 'Search CoinGecko for a coin id', tags: ['Holdings'], responses: [
+        new OA\Response(response: 200, description: 'Matching coins'),
+    ])]
+    public function search(Request $request): JsonResponse
+    {
+        $request->validate(['q' => 'required|string|min:1']);
+
+        return $this->success($this->assetPrices->searchCoins((string) $request->query('q')));
+    }
+}

--- a/app/Http/Controllers/API/v1/StatsController.php
+++ b/app/Http/Controllers/API/v1/StatsController.php
@@ -68,7 +68,7 @@ class StatsController extends ApiController
                 required: false,
                 schema: new OA\Schema(
                     type: 'string',
-                    enum: ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow'],
+                    enum: ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow', 'position'],
                     description: 'Compute only one section of the response for progressive loading. Omit for the full payload.'
                 )
             ),

--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\API\v1;
 
+use App\Enums\TransactionIntent;
 use App\Http\Controllers\API\ApiController;
 use App\Http\Traits\ApiQueryable;
 use App\Jobs\RecurrentTransactionJob;
 use App\Models\RecurringTransactionRule;
 use App\Models\Transaction;
+use App\Models\User;
 use App\Rules\Iso8601DateTime;
 use App\Rules\ValidateClientId;
 use App\Services\FileService;
@@ -77,6 +79,13 @@ class TransactionController extends ApiController
                 required: false,
                 schema: new OA\Schema(type: 'string')
             ),
+            new OA\Parameter(
+                name: 'intent',
+                description: 'Filter by one or more transaction intents (comma-separated)',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', example: 'investment_buy,investment_return')
+            ),
             new OA\Parameter(ref: '#/components/parameters/limitParam'),
             new OA\Parameter(ref: '#/components/parameters/syncedSinceParam'),
             new OA\Parameter(ref: '#/components/parameters/noClientIdParam'),
@@ -112,7 +121,7 @@ class TransactionController extends ApiController
             return $this->failure(__('Invalid transaction type'), 400);
         }
 
-        /** @var \App\Models\User $user */
+        /** @var User $user */
         $user = auth()->user();
         $query = $user->transactions()->orderBy('datetime', 'desc')->orderBy('created_at', 'desc');
         if (! empty($type)) {
@@ -230,6 +239,15 @@ class TransactionController extends ApiController
                         ),
                         new OA\Property(property: 'amount', type: 'number', format: 'float'),
                         new OA\Property(property: 'type', type: 'string', enum: ['income', 'expense']),
+                        new OA\Property(
+                            property: 'intent',
+                            type: 'string',
+                            enum: [
+                                'regular', 'loan_received', 'loan_repayment', 'debt_owed',
+                                'debt_settled', 'investment_buy', 'investment_return', 'gift',
+                            ],
+                            default: 'regular'
+                        ),
                         new OA\Property(property: 'description', type: 'string'),
                         new OA\Property(property: 'datetime', type: 'string', format: 'date-time'),
                         new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
@@ -299,6 +317,7 @@ class TransactionController extends ApiController
             'client_id' => ['nullable', 'string', new ValidateClientId()],
             'amount' => 'required|numeric|min:0.01',
             'type' => 'required|string|in:income,expense',
+            'intent' => 'nullable|string|in:' . implode(',', TransactionIntent::values()),
             'description' => 'nullable|string',
             'datetime' => ['nullable', new Iso8601DateTime()],
             'created_at' => ['nullable', new Iso8601DateTime()],
@@ -528,6 +547,15 @@ class TransactionController extends ApiController
                     ),
                     new OA\Property(property: 'amount', type: 'number', format: 'float'),
                     new OA\Property(property: 'type', type: 'string', enum: ['income', 'expense']),
+                    new OA\Property(
+                        property: 'intent',
+                        type: 'string',
+                        enum: [
+                            'regular', 'loan_received', 'loan_repayment', 'debt_owed',
+                            'debt_settled', 'investment_buy', 'investment_return', 'gift',
+                        ],
+                        default: 'regular'
+                    ),
                     new OA\Property(property: 'date', type: 'string', format: 'date'),
                     new OA\Property(property: 'party_id', type: 'integer'),
                     new OA\Property(property: 'group_id', type: 'integer'),
@@ -604,6 +632,7 @@ class TransactionController extends ApiController
             'client_id' => ['nullable', 'string', new ValidateClientId()],
             'amount' => 'nullable|numeric|min:0.01',
             'type' => 'nullable|string|in:income,expense',
+            'intent' => 'nullable|string|in:' . implode(',', TransactionIntent::values()),
             'datetime' => ['nullable', new Iso8601DateTime()],
             'description' => 'nullable|string',
             'party_id' => 'nullable|integer|exists:parties,id',
@@ -813,7 +842,6 @@ class TransactionController extends ApiController
         return $this->success(['message' => __('Transaction deleted successfully')]);
     }
 
-
     /**
      * Apply optional filtering query parameters (date range, wallets,
      * categories, search) to the given transaction query.
@@ -828,23 +856,58 @@ class TransactionController extends ApiController
             $query->whereDate('datetime', '<=', $request->query('date_to'));
         }
 
-        $walletIds = $request->query('wallet_ids');
+        $walletIds = $this->listParam($request, 'wallet_ids');
         if (! empty($walletIds)) {
-            $walletIds = is_array($walletIds) ? $walletIds : [$walletIds];
             $query->whereIn('wallet_id', $walletIds);
         }
 
-        $categoryIds = $request->query('category_ids');
+        $categoryIds = $this->listParam($request, 'category_ids');
         if (! empty($categoryIds)) {
-            $categoryIds = is_array($categoryIds) ? $categoryIds : [$categoryIds];
             $query->whereHas('categories', function ($q) use ($categoryIds) {
                 $q->whereIn('categories.id', $categoryIds);
             });
         }
 
+        $this->applyIntentFilters($query, $request);
+
         if ($request->filled('search')) {
             $this->applySearchFilter($query, (string) $request->query('search'));
         }
+    }
+
+    private function applyIntentFilters($query, Request $request): void
+    {
+        $intents = array_values(array_intersect(
+            $this->listParam($request, 'intent'),
+            TransactionIntent::values()
+        ));
+        if (! empty($intents)) {
+            $query->whereIn('intent', $intents);
+        }
+
+        if ($request->boolean('exclude_transfers')) {
+            $query->nonTransfer();
+        }
+    }
+
+    /**
+     * Parse a list query parameter that may arrive either as an array
+     * (key[]=a&key[]=b) or a comma-separated string (key=a,b), returning a
+     * trimmed list with empty entries removed.
+     */
+    private function listParam(Request $request, string $key): array
+    {
+        $value = $request->query($key);
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        $items = is_array($value) ? $value : explode(',', (string) $value);
+
+        return array_values(array_filter(
+            array_map('trim', $items),
+            fn ($item) => $item !== ''
+        ));
     }
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -112,6 +112,7 @@ class Transaction extends Model
         'datetime',
         'description',
         'type',
+        'intent',
         'party_id',
         'wallet_id',
         'user_id',
@@ -128,6 +129,10 @@ class Transaction extends Model
     protected $casts = [
         'datetime' => 'datetime',
         'amount' => 'decimal:2',
+    ];
+
+    protected $attributes = [
+        'intent' => 'regular',
     ];
 
     protected $hidden = ['transfer'];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -87,6 +87,11 @@ class User extends Authenticatable implements HasLocalePreference
         return $this->hasMany(Wallet::class);
     }
 
+    public function holdings(): HasMany
+    {
+        return $this->hasMany(Holding::class);
+    }
+
     public function transactions(): HasMany
     {
         return $this->hasMany(Transaction::class);

--- a/app/Observers/HoldingObserver.php
+++ b/app/Observers/HoldingObserver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use App\Services\StatsService;
+use Whilesmart\Holdings\Models\Holding;
+
+class HoldingObserver
+{
+    public function created(Holding $holding): void
+    {
+        $this->invalidate($holding);
+    }
+
+    public function updated(Holding $holding): void
+    {
+        $this->invalidate($holding);
+    }
+
+    public function deleted(Holding $holding): void
+    {
+        $this->invalidate($holding);
+    }
+
+    protected function invalidate(Holding $holding): void
+    {
+        if ($holding->owner_type === User::class && $holding->owner_id) {
+            StatsService::invalidateUserCache((int) $holding->owner_id);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,6 +30,15 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton(OwnerResolver::class, UserOwnerResolver::class);
 
+        $this->app->bind(
+            \Whilesmart\OwnerAccess\Contracts\OwnerAuthorizer::class,
+            \App\Holdings\UserOwnerAuthorizer::class
+        );
+        $this->app->bind(
+            \Whilesmart\Holdings\Contracts\HoldingPriceProvider::class,
+            \App\Holdings\CoingeckoPriceProvider::class
+        );
+
         $this->app->singleton(Entitlements::class, AllowAllEntitlements::class);
 
         $this->app->singleton(IntegrationRegistry::class);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -61,6 +61,7 @@ class EventServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Transaction::observe(TransactionObserver::class);
+        \Whilesmart\Holdings\Models\Holding::observe(\App\Observers\HoldingObserver::class);
     }
 
     /**

--- a/app/Services/AssetPriceService.php
+++ b/app/Services/AssetPriceService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Fetches live crypto prices from CoinGecko (free, no key). On any API failure
+ * it returns empty so callers keep the last known price.
+ */
+class AssetPriceService
+{
+    protected string $apiUrl = 'https://api.coingecko.com/api/v3';
+
+    /**
+     * Current price per coin id in the given fiat currency.
+     *
+     * @param  string[]  $coingeckoIds
+     * @return array<string, float>  keyed by coingecko id
+     */
+    public function fetchPrices(array $coingeckoIds, string $vsCurrency): array
+    {
+        $coingeckoIds = array_values(array_unique(array_filter($coingeckoIds)));
+        if ($coingeckoIds === []) {
+            return [];
+        }
+
+        $vsCurrency = strtolower($vsCurrency);
+
+        try {
+            $response = Http::timeout(10)->get("{$this->apiUrl}/simple/price", [
+                'ids' => implode(',', $coingeckoIds),
+                'vs_currencies' => $vsCurrency,
+            ]);
+
+            if (! $response->successful()) {
+                Log::warning('CoinGecko price fetch failed', ['status' => $response->status()]);
+
+                return [];
+            }
+
+            $prices = [];
+            foreach ($response->json() as $id => $quote) {
+                if (isset($quote[$vsCurrency])) {
+                    $prices[$id] = (float) $quote[$vsCurrency];
+                }
+            }
+
+            return $prices;
+        } catch (\Throwable $e) {
+            Log::warning('CoinGecko price fetch error: ' . $e->getMessage());
+
+            return [];
+        }
+    }
+
+    /**
+     * Search CoinGecko for coins matching a query so the client can resolve a
+     * name to its coingecko id.
+     *
+     * @return array<int, array{id: string, name: string, symbol: string}>
+     */
+    public function searchCoins(string $query): array
+    {
+        $query = trim($query);
+        if ($query === '') {
+            return [];
+        }
+
+        try {
+            $response = Http::timeout(10)->get("{$this->apiUrl}/search", ['query' => $query]);
+
+            if (! $response->successful()) {
+                return [];
+            }
+
+            return collect($response->json('coins') ?? [])
+                ->take(20)
+                ->map(fn ($coin) => [
+                    'id' => $coin['id'] ?? '',
+                    'name' => $coin['name'] ?? '',
+                    'symbol' => strtoupper($coin['symbol'] ?? ''),
+                ])
+                ->filter(fn ($coin) => $coin['id'] !== '')
+                ->values()
+                ->all();
+        } catch (\Throwable $e) {
+            Log::warning('CoinGecko search error: ' . $e->getMessage());
+
+            return [];
+        }
+    }
+}

--- a/app/Services/StatsService.php
+++ b/app/Services/StatsService.php
@@ -2,11 +2,18 @@
 
 namespace App\Services;
 
+use App\Enums\TransactionIntent;
 use App\Models\Transaction;
+use App\Models\User;
 use App\Models\Wallet;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
+use Whilesmart\Holdings\Models\Holding;
 
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
 class StatsService
 {
     private $user;
@@ -38,7 +45,7 @@ class StatsService
      * for a single section computes only that section so the client can load
      * the dashboard progressively instead of waiting for the whole payload.
      */
-    public const SECTIONS = ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow'];
+    public const SECTIONS = ['overview', 'activity', 'comparisons', 'categories', 'parties', 'cashflow', 'position'];
 
     /**
      * Compute stats for the given parameters. When $section is null the full
@@ -118,6 +125,7 @@ class StatsService
                     'expense_by_wallet' => $this->getExpenseByWalletData(),
                 ],
             ],
+            'position' => [['position' => $this->getFinancialPosition()], []],
             default => [[], []],
         };
     }
@@ -147,6 +155,80 @@ class StatsService
         }
 
         return ['overview' => $overview, 'period_summary' => $this->getPeriodSummary()];
+    }
+
+    /**
+     * Financial Position: separates real earned income and discretionary spend
+     * from loan, debt and investment movement so borrowed money is not counted
+     * as earnings. Driven by each transaction's intent tag.
+     */
+    private function getFinancialPosition(): array
+    {
+        $rows = $this->baseJoinedQuery()
+            ->select('transactions.type', 'transactions.intent', 'wallets.currency')
+            ->selectRaw('SUM(transactions.amount) as total_amount')
+            ->groupBy('transactions.type', 'transactions.intent', 'wallets.currency')
+            ->get();
+
+        // Conversion is linear, so summing per currency in the database and
+        // converting each group once matches converting every row individually.
+        $byIntent = array_fill_keys(TransactionIntent::values(), 0.0);
+        $earnedIncome = 0.0;
+        $discretionarySpend = 0.0;
+
+        foreach ($rows as $row) {
+            $amount = $this->convertCurrency((float) $row->total_amount, $row->currency);
+            $intent = TransactionIntent::tryFrom($row->intent ?? 'regular') ?? TransactionIntent::REGULAR;
+
+            if ($intent === TransactionIntent::REGULAR) {
+                if ($row->type === 'income') {
+                    $earnedIncome += $amount;
+                } else {
+                    $discretionarySpend += $amount;
+                }
+
+                continue;
+            }
+
+            $byIntent[$intent->value] += $amount;
+        }
+
+        $loanReceived = $byIntent[TransactionIntent::LOAN_RECEIVED->value];
+        $loanRepayment = $byIntent[TransactionIntent::LOAN_REPAYMENT->value];
+        $debtOwed = $byIntent[TransactionIntent::DEBT_OWED->value];
+        $debtSettled = $byIntent[TransactionIntent::DEBT_SETTLED->value];
+        $investmentPrincipal = $byIntent[TransactionIntent::INVESTMENT_BUY->value];
+        $investmentReturns = $byIntent[TransactionIntent::INVESTMENT_RETURN->value];
+        $giftsReceived = $byIntent[TransactionIntent::GIFT->value];
+
+        // Buying an investment moves cash into an asset of equal value, so it is
+        // net-worth-neutral and excluded here (the app does not track asset
+        // market value). Loans and debt are likewise balance-neutral. Only real
+        // earnings, realised returns and gifts build net worth; spending erodes it.
+        $netWorthDelta = $earnedIncome
+            - $discretionarySpend
+            + $investmentReturns
+            + $giftsReceived;
+
+        $cashBalance = $this->getTotalBalance();
+        $holdingsValue = $this->getHoldingsValue();
+
+        return [
+            'earned_income' => $earnedIncome,
+            'cash_balance' => $cashBalance,
+            'holdings_value' => $holdingsValue,
+            'total_net_worth' => $cashBalance + $holdingsValue,
+            'discretionary_spend' => $discretionarySpend,
+            'loan_received' => $loanReceived,
+            'loan_repayment' => $loanRepayment,
+            'debt_owed' => $debtOwed,
+            'debt_settled' => $debtSettled,
+            'loans_debt_net' => ($loanReceived + $debtOwed) - ($loanRepayment + $debtSettled),
+            'investment_principal' => $investmentPrincipal,
+            'investment_returns' => $investmentReturns,
+            'gifts_received' => $giftsReceived,
+            'net_worth_delta' => $netWorthDelta,
+        ];
     }
 
     /**
@@ -198,7 +280,7 @@ class StatsService
     /**
      * Base query with wallet join for currency access.
      */
-    private function baseJoinedQuery(): \Illuminate\Database\Eloquent\Builder
+    private function baseJoinedQuery(): Builder
     {
         $query = Transaction::join('wallets', 'transactions.wallet_id', '=', 'wallets.id')
             ->where('transactions.user_id', $this->user->id)
@@ -216,7 +298,7 @@ class StatsService
     /**
      * Base query with eager-loaded relationships.
      */
-    private function baseEagerQuery(array $relations = ['wallet']): \Illuminate\Database\Eloquent\Builder
+    private function baseEagerQuery(array $relations = ['wallet']): Builder
     {
         $query = Transaction::with($relations)
             ->where('user_id', $this->user->id)
@@ -233,7 +315,7 @@ class StatsService
     /**
      * Base query with table-qualified columns for joins.
      */
-    private function baseQualifiedQuery(): \Illuminate\Database\Eloquent\Builder
+    private function baseQualifiedQuery(): Builder
     {
         $query = Transaction::where('transactions.user_id', $this->user->id)
             ->nonTransfer()
@@ -291,6 +373,25 @@ class StatsService
 
         foreach ($wallets as $wallet) {
             $total += $this->convertCurrency((float) $wallet->balance, $wallet->currency);
+        }
+
+        return $total;
+    }
+
+    /**
+     * Current market value of all the user's holdings, converted to the target
+     * currency. Holdings are user-wide and not scoped by the wallet filter.
+     */
+    private function getHoldingsValue(): float
+    {
+        $total = 0.0;
+
+        $holdings = Holding::where('owner_type', User::class)
+            ->where('owner_id', $this->user->id)
+            ->get();
+
+        foreach ($holdings as $holding) {
+            $total += $this->convertCurrency((float) $holding->value, $holding->currency);
         }
 
         return $total;

--- a/app/Support/ConfigurationKeys.php
+++ b/app/Support/ConfigurationKeys.php
@@ -24,6 +24,12 @@ class ConfigurationKeys
     public const LAST_INACTIVITY_REMINDER_SENT = 'last-inactivity-reminder-sent';
     public const WALLETS_ALLOW_NEGATIVE_BALANCE = 'wallets-allow-negative-balance';
 
+    public const TRANSACTION_INTENTS_ENABLED = 'transaction-intents-enabled';
+
+    public const ASSET_TRACKING_ENABLED = 'asset-tracking-enabled';
+
+    public const LANDING_EXPERIENCE = 'landing-experience';
+
     public const NAMES = [
         self::DEFAULT_WALLET,
         self::DEFAULT_CURRENCY,
@@ -44,6 +50,9 @@ class ConfigurationKeys
         self::INACTIVITY_REMINDER_COUNT,
         self::LAST_INACTIVITY_REMINDER_SENT,
         self::WALLETS_ALLOW_NEGATIVE_BALANCE,
+        self::TRANSACTION_INTENTS_ENABLED,
+        self::ASSET_TRACKING_ENABLED,
+        self::LANDING_EXPERIENCE,
     ];
 
     public const RULES = [
@@ -66,5 +75,8 @@ class ConfigurationKeys
         self::INACTIVITY_REMINDER_COUNT => 'integer|min:0',
         self::LAST_INACTIVITY_REMINDER_SENT => 'date',
         self::WALLETS_ALLOW_NEGATIVE_BALANCE => 'boolean',
+        self::TRANSACTION_INTENTS_ENABLED => 'boolean',
+        self::ASSET_TRACKING_ENABLED => 'boolean',
+        self::LANDING_EXPERIENCE => 'string|in:chat,dashboard',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "smartpings/php-sdk": "dev-main",
         "whilesmart/eloquent-activities": "^1.0",
         "whilesmart/eloquent-agents": "dev-main",
+        "whilesmart/eloquent-holdings": "^1.0",
         "whilesmart/eloquent-model-configuration": "^1.0.9",
         "whilesmart/eloquent-roles": "dev-dev",
         "whilesmart/laravel-plugin-engine": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2843f02ae7b0c06b628e0dcef9347441",
+    "content-hash": "4a25ad621db24aa1be6cd13837be9453",
     "packages": [
         {
             "name": "beste/clock",
@@ -8601,6 +8601,60 @@
             "time": "2026-06-14T16:23:46+00:00"
         },
         {
+            "name": "whilesmart/eloquent-holdings",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whilesmartphp/eloquent-holdings.git",
+                "reference": "f58e8543f0ea10fa24458aed26f736426b16fc52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whilesmartphp/eloquent-holdings/zipball/f58e8543f0ea10fa24458aed26f736426b16fc52",
+                "reference": "f58e8543f0ea10fa24458aed26f736426b16fc52",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.0|^12.0",
+                "php": "^8.2",
+                "whilesmart/eloquent-owner-access": "^1.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.24",
+                "laravel/pint": "^1.22",
+                "orchestra/testbench": "^9.0|^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Whilesmart\\Holdings\\HoldingsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whilesmart\\Holdings\\": "src/",
+                    "Whilesmart\\Holdings\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Whilesmart Team"
+                }
+            ],
+            "description": "Polymorphic holdings register (crypto, stocks, property, any asset) for Laravel: track quantity and value, with pluggable live pricing.",
+            "support": {
+                "issues": "https://github.com/whilesmartphp/eloquent-holdings/issues",
+                "source": "https://github.com/whilesmartphp/eloquent-holdings/tree/v1.0.0"
+            },
+            "time": "2026-06-27T11:16:36+00:00"
+        },
+        {
             "name": "whilesmart/eloquent-model-configuration",
             "version": "1.0.11",
             "source": {
@@ -8653,6 +8707,57 @@
                 "source": "https://github.com/whilesmartphp/eloquent-model-configs/tree/v1.0.11"
             },
             "time": "2026-01-11T10:14:02+00:00"
+        },
+        {
+            "name": "whilesmart/eloquent-owner-access",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whilesmartphp/eloquent-owner-access.git",
+                "reference": "3edbda3296eca3bbb141b7f8368fd482308677b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whilesmartphp/eloquent-owner-access/zipball/3edbda3296eca3bbb141b7f8368fd482308677b0",
+                "reference": "3edbda3296eca3bbb141b7f8368fd482308677b0",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.0|^12.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.22",
+                "orchestra/testbench": "^9.0|^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Whilesmart\\OwnerAccess\\OwnerAccessServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whilesmart\\OwnerAccess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Whilesmart Team"
+                }
+            ],
+            "description": "Pluggable polymorphic owner authorization for Laravel packages with owner_type/owner_id columns. Lets host apps decide who can see and modify owner-scoped records without coupling the underlying packages to a specific tenancy model.",
+            "support": {
+                "issues": "https://github.com/whilesmartphp/eloquent-owner-access/issues",
+                "source": "https://github.com/whilesmartphp/eloquent-owner-access/tree/v1.0.0"
+            },
+            "time": "2026-06-10T17:45:50+00:00"
         },
         {
             "name": "whilesmart/eloquent-roles",

--- a/config/agents.php
+++ b/config/agents.php
@@ -57,6 +57,7 @@ return [
         App\Ai\Tools\Read\ListWalletsTool::class,
         App\Ai\Tools\Read\ListCategoriesTool::class,
         App\Ai\Tools\Read\ListPartiesTool::class,
+        App\Ai\Tools\Read\ListHoldingsTool::class,
         App\Ai\Tools\Render\RenderKpiTool::class,
         App\Ai\Tools\Render\RenderChartTool::class,
         App\Ai\Tools\Render\RenderTableTool::class,

--- a/config/holdings.php
+++ b/config/holdings.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'register_routes' => env('HOLDINGS_REGISTER_ROUTES', true),
+    'route_prefix' => env('HOLDINGS_ROUTE_PREFIX', 'api/v1'),
+    'route_middleware' => ['api', 'auth:sanctum'],
+    'holdings_table' => env('HOLDINGS_TABLE', 'holdings'),
+
+    // Default fiat currency for new holdings when none is supplied.
+    'default_currency' => env('HOLDINGS_DEFAULT_CURRENCY', 'USD'),
+];

--- a/database/migrations/2026_06_21_000000_add_intent_to_transactions_table.php
+++ b/database/migrations/2026_06_21_000000_add_intent_to_transactions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->string('intent')->default('regular')->after('type')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropIndex(['intent']);
+            $table->dropColumn('intent');
+        });
+    }
+};

--- a/database/seeders/TransactionSeeder.php
+++ b/database/seeders/TransactionSeeder.php
@@ -9,12 +9,12 @@ use Illuminate\Database\Seeder;
 
 class TransactionSeeder extends Seeder
 {
+    // Earned income only: gifts and investment returns are seeded separately as
+    // intent-tagged transactions so they are not double-counted here.
     private array $incomeTemplates = [
         ['category' => 'Salary', 'party' => 'Acme Corporation', 'amount_range' => [2500, 4000], 'description' => 'Monthly salary', 'weight' => 1],
         ['category' => 'Freelance', 'party' => 'TechStart Inc', 'amount_range' => [300, 1200], 'description' => 'Freelance project', 'weight' => 2],
         ['category' => 'Freelance', 'party' => 'Digital Solutions Ltd', 'amount_range' => [200, 800], 'description' => 'Contract work', 'weight' => 2],
-        ['category' => 'Investments', 'party' => 'Investment Portfolio', 'amount_range' => [50, 300], 'description' => 'Dividend payment', 'weight' => 1],
-        ['category' => 'Gifts', 'party' => 'Family', 'amount_range' => [20, 200], 'description' => 'Gift received', 'weight' => 1],
         ['category' => 'Refunds', 'party' => 'Amazon', 'amount_range' => [10, 100], 'description' => 'Refund', 'weight' => 1],
     ];
 
@@ -103,8 +103,10 @@ class TransactionSeeder extends Seeder
             // Monthly bills (rent, subscriptions, insurance - once per month)
             $monthlyBills = ['Rent', 'Netflix', 'Spotify', 'Insurance'];
             foreach ($this->expenseTemplates as $template) {
-                if (in_array($template['category'], $monthlyBills) ||
-                    in_array($template['party'], ['City Properties', 'Netflix', 'Spotify', 'State Insurance'])) {
+                if (
+                    in_array($template['category'], $monthlyBills) ||
+                    in_array($template['party'], ['City Properties', 'Netflix', 'Spotify', 'State Insurance'])
+                ) {
                     if ($categories->has($template['category']) && $parties->has($template['party'])) {
                         // Skip some months randomly for non-essential subscriptions
                         if ($template['party'] !== 'City Properties' && rand(1, 10) <= 2) {
@@ -143,6 +145,8 @@ class TransactionSeeder extends Seeder
             }
         }
 
+        $this->createIntentTransactions($user, $categories, $parties, $wallets);
+
         // Shuffle all transactions to mix income and expenses
         shuffle($allTransactions);
 
@@ -162,7 +166,6 @@ class TransactionSeeder extends Seeder
                 $txnData['date']
             );
         }
-
     }
 
     private function createRecentTransactions(array &$allTransactions, $categories, $parties): void
@@ -252,7 +255,7 @@ class TransactionSeeder extends Seeder
         };
     }
 
-    private function createTransaction($user, $category, $party, $wallet, $type, $amountRange, $description, $date): void
+    private function createTransaction($user, $category, $party, $wallet, $type, $amountRange, $description, $date, string $intent = 'regular'): void
     {
         $amount = rand($amountRange[0] * 100, $amountRange[1] * 100) / 100;
 
@@ -262,10 +265,49 @@ class TransactionSeeder extends Seeder
             'wallet_id' => $wallet->id,
             'amount' => $amount,
             'type' => $type,
+            'intent' => $intent,
             'description' => $description,
             'datetime' => $date,
         ]);
 
-        $transaction->categories()->attach($category->id);
+        if ($category !== null) {
+            $transaction->categories()->attach($category->id);
+        }
+    }
+
+    /**
+     * Seed intent-tagged loan, debt, investment and gift transactions. Relies on
+     * the default seeded parties and categories being present.
+     */
+    private function createIntentTransactions(User $user, $categories, $parties, $wallets): void
+    {
+        $family = $parties->get('Family');
+        $portfolio = $parties->get('Investment Portfolio');
+
+        if ($family === null || $portfolio === null) {
+            return;
+        }
+
+        $bankWallet = $wallets->firstWhere('name', 'Main Checking') ?? $wallets->first();
+        $savings = $wallets->firstWhere('name', 'Savings Account') ?? $bankWallet;
+        $cashWallet = $wallets->firstWhere('name', 'Main Wallet') ?? $bankWallet;
+
+        $investmentsCat = $categories->get('Investments');
+        $giftsCat = $categories->get('Gifts');
+
+        $this->createTransaction($user, null, $family, $bankWallet, 'income', [4000, 7000], 'Personal loan received', Carbon::now()->subMonths(2)->addDays(3), 'loan_received');
+
+        for ($month = 1; $month >= 0; $month--) {
+            $this->createTransaction($user, null, $family, $bankWallet, 'expense', [400, 600], 'Loan repayment', Carbon::now()->subMonths($month)->addDays(10), 'loan_repayment');
+        }
+
+        $this->createTransaction($user, null, $family, $bankWallet, 'income', [200, 500], 'Repaid by a friend', Carbon::now()->subMonths(1)->addDays(15), 'debt_owed');
+        $this->createTransaction($user, null, $family, $bankWallet, 'expense', [100, 300], 'Settled what I owed', Carbon::now()->subDays(20), 'debt_settled');
+
+        $this->createTransaction($user, $investmentsCat, $portfolio, $savings, 'expense', [800, 2000], 'Investment purchase', Carbon::now()->subMonths(2)->addDays(8), 'investment_buy');
+        $this->createTransaction($user, $investmentsCat, $portfolio, $savings, 'expense', [500, 1500], 'Investment purchase', Carbon::now()->subMonths(1)->addDays(5), 'investment_buy');
+        $this->createTransaction($user, $investmentsCat, $portfolio, $bankWallet, 'income', [80, 400], 'Investment return', Carbon::now()->subDays(12), 'investment_return');
+
+        $this->createTransaction($user, $giftsCat, $family, $cashWallet, 'income', [50, 250], 'Gift received', Carbon::now()->subDays(6), 'gift');
     }
 }

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -578,6 +578,20 @@
                 }
             }
         },
+        "/asset-prices/search": {
+            "get": {
+                "tags": [
+                    "Holdings"
+                ],
+                "summary": "Search CoinGecko for a coin id",
+                "operationId": "c77e77d29462543ff689cd7a7cf53fed",
+                "responses": {
+                    "200": {
+                        "description": "Matching coins"
+                    }
+                }
+            }
+        },
         "/budgets": {
             "get": {
                 "tags": [
@@ -3226,7 +3240,8 @@
                                 "comparisons",
                                 "categories",
                                 "parties",
-                                "cashflow"
+                                "cashflow",
+                                "position"
                             ]
                         }
                     }
@@ -3368,6 +3383,16 @@
                         }
                     },
                     {
+                        "name": "intent",
+                        "in": "query",
+                        "description": "Filter by one or more transaction intents (comma-separated)",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "investment_buy,investment_return"
+                        }
+                    },
+                    {
                         "$ref": "#/components/parameters/limitParam"
                     },
                     {
@@ -3436,6 +3461,20 @@
                                         "enum": [
                                             "income",
                                             "expense"
+                                        ]
+                                    },
+                                    "intent": {
+                                        "type": "string",
+                                        "default": "regular",
+                                        "enum": [
+                                            "regular",
+                                            "loan_received",
+                                            "loan_repayment",
+                                            "debt_owed",
+                                            "debt_settled",
+                                            "investment_buy",
+                                            "investment_return",
+                                            "gift"
                                         ]
                                     },
                                     "description": {
@@ -3707,6 +3746,20 @@
                                         "enum": [
                                             "income",
                                             "expense"
+                                        ]
+                                    },
+                                    "intent": {
+                                        "type": "string",
+                                        "default": "regular",
+                                        "enum": [
+                                            "regular",
+                                            "loan_received",
+                                            "loan_repayment",
+                                            "debt_owed",
+                                            "debt_settled",
+                                            "investment_buy",
+                                            "investment_return",
+                                            "gift"
                                         ]
                                     },
                                     "date": {
@@ -4579,7 +4632,10 @@
                                             "inactivity-reminders-enabled",
                                             "inactivity-reminder-count",
                                             "last-inactivity-reminder-sent",
-                                            "wallets-allow-negative-balance"
+                                            "wallets-allow-negative-balance",
+                                            "transaction-intents-enabled",
+                                            "asset-tracking-enabled",
+                                            "landing-experience"
                                         ],
                                         "example": "theme"
                                     },
@@ -4661,7 +4717,10 @@
                                 "inactivity-reminders-enabled",
                                 "inactivity-reminder-count",
                                 "last-inactivity-reminder-sent",
-                                "wallets-allow-negative-balance"
+                                "wallets-allow-negative-balance",
+                                "transaction-intents-enabled",
+                                "asset-tracking-enabled",
+                                "landing-experience"
                             ]
                         }
                     }
@@ -4716,7 +4775,10 @@
                                 "inactivity-reminders-enabled",
                                 "inactivity-reminder-count",
                                 "last-inactivity-reminder-sent",
-                                "wallets-allow-negative-balance"
+                                "wallets-allow-negative-balance",
+                                "transaction-intents-enabled",
+                                "asset-tracking-enabled",
+                                "landing-experience"
                             ]
                         }
                     }
@@ -4809,7 +4871,10 @@
                                 "inactivity-reminders-enabled",
                                 "inactivity-reminder-count",
                                 "last-inactivity-reminder-sent",
-                                "wallets-allow-negative-balance"
+                                "wallets-allow-negative-balance",
+                                "transaction-intents-enabled",
+                                "asset-tracking-enabled",
+                                "landing-experience"
                             ]
                         }
                     }
@@ -6259,6 +6324,10 @@
         {
             "name": "Admin",
             "description": "Admin"
+        },
+        {
+            "name": "Holdings",
+            "description": "Holdings"
         },
         {
             "name": "Groups",

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\API\v1\TransactionController;
 use App\Http\Controllers\API\v1\TransactionRefundController;
 use App\Http\Controllers\API\v1\TransferController;
 use App\Http\Controllers\API\v1\UserController;
+use App\Http\Controllers\API\v1\AssetPriceController;
 use App\Http\Controllers\API\v1\WalletController;
 use App\Http\Controllers\API\VersionController;
 use Illuminate\Support\Facades\Route;
@@ -45,6 +46,8 @@ Route::group(['prefix' => 'v1', 'middleware' => ['auth:sanctum']], function () {
         Route::apiResource('parties', PartyController::class);
         Route::apiResource('wallets', WalletController::class);
         Route::apiResource('transfers', TransferController::class);
+
+        Route::get('asset-prices/search', [AssetPriceController::class, 'search']);
 
         Route::get('stats', [StatsController::class, 'index']);
     });

--- a/smartql.yml
+++ b/smartql.yml
@@ -33,6 +33,9 @@ semantic_layer:
         type:
           type: string
           description: "Transaction type: 'income' or 'expense'"
+        intent:
+          type: string
+          description: "What the money movement is: regular, loan_received, loan_repayment, debt_owed, debt_settled, investment_buy, investment_return, gift"
         datetime:
           type: datetime
           description: "When the transaction occurred"
@@ -121,6 +124,39 @@ semantic_layer:
         categorizable_type:
           type: string
           description: "Always 'App\\Models\\Transaction'"
+
+    holdings:
+      table: holdings
+      description: "Owned assets (crypto, stocks, property) tracked by quantity and unit price; value = quantity * unit_price"
+      aliases: [assets, investments, crypto, stocks, portfolio, net worth]
+      columns:
+        id:
+          type: integer
+          primary: true
+        name:
+          type: string
+          description: "Asset name (e.g. Bitcoin, Apple, Rental flat)"
+        symbol:
+          type: string
+          description: "Ticker or short symbol"
+        quantity:
+          type: decimal
+          description: "Units held"
+        currency:
+          type: string
+          description: "Currency the unit price is denominated in"
+        unit_price:
+          type: decimal
+          description: "Current price per unit"
+        price_source:
+          type: string
+          description: "'manual' or 'auto' (live-priced)"
+        owner_type:
+          type: string
+          description: "Always 'App\\Models\\User'"
+        owner_id:
+          type: integer
+          description: "Owner of the holding"
 
   relationships:
     - name: transaction_wallet

--- a/tests/Feature/AgentActionTest.php
+++ b/tests/Feature/AgentActionTest.php
@@ -99,6 +99,47 @@ class AgentActionTest extends TestCase
         ]);
     }
 
+    public function test_record_transaction_carries_intent_through_confirm(): void
+    {
+        $action = $this->propose([
+            'amount' => 5000,
+            'type' => 'income',
+            'wallet_name' => 'Cash',
+            'intent' => 'loan_received',
+        ]);
+
+        $this->assertEquals('loan_received', $action->payload['intent']);
+
+        $this->actingAs($this->user)
+            ->postJson("/api/v1/ai/chats/{$this->session->id}/actions/{$action->id}/confirm")
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('transactions', [
+            'user_id' => $this->user->id,
+            'amount' => 5000,
+            'type' => 'income',
+            'intent' => 'loan_received',
+        ]);
+    }
+
+    public function test_record_transaction_rejects_unknown_intent(): void
+    {
+        $this->app->instance(BlockCollector::class, new BlockCollector());
+        $tool = $this->app->make(RecordTransactionTool::class);
+        $context = ToolContext::forUser($this->user, 'en', ['chat_session_id' => $this->session->id]);
+
+        $before = AgentProposedAction::count();
+        $out = $tool->handle([
+            'amount' => 20,
+            'type' => 'expense',
+            'wallet_name' => 'Cash',
+            'intent' => 'not_a_real_intent',
+        ], $context);
+
+        $this->assertArrayHasKey('error', $out);
+        $this->assertSame($before, AgentProposedAction::count(), 'An invalid intent must not persist a proposal.');
+    }
+
     public function test_confirm_is_idempotent(): void
     {
         $action = $this->propose(['amount' => 20, 'type' => 'expense', 'wallet_name' => 'Cash']);

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -28,6 +28,39 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
+    public function test_landing_experience_can_be_saved_and_updated()
+    {
+        $this->actingAs($this->user)->postJson('/api/v1/configurations', [
+            'key' => 'landing-experience',
+            'type' => 'string',
+            'value' => 'dashboard',
+        ])->assertStatus(201);
+
+        $this->assertEquals(
+            'dashboard',
+            $this->user->fresh()->getConfigValue(\App\Support\ConfigurationKeys::LANDING_EXPERIENCE)
+        );
+
+        $this->actingAs($this->user)->putJson('/api/v1/configurations/landing-experience', [
+            'type' => 'string',
+            'value' => 'chat',
+        ])->assertStatus(200);
+
+        $this->assertEquals(
+            'chat',
+            $this->user->fresh()->getConfigValue(\App\Support\ConfigurationKeys::LANDING_EXPERIENCE)
+        );
+    }
+
+    public function test_landing_experience_rejects_invalid_value()
+    {
+        $this->actingAs($this->user)->postJson('/api/v1/configurations', [
+            'key' => 'landing-experience',
+            'type' => 'string',
+            'value' => 'not-a-mode',
+        ])->assertStatus(422);
+    }
+
     public function test_api_user_can_not_create_config_with_unallowed_key()
     {
         $response = $this->actingAs($this->user)->postJson('/api/v1/configurations', [

--- a/tests/Feature/HoldingsAiToolsTest.php
+++ b/tests/Feature/HoldingsAiToolsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Ai\Tools\Read\GetStatsTool;
+use App\Ai\Tools\Read\ListHoldingsTool;
+use App\Models\User;
+use App\Models\Wallet;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Whilesmart\Agents\ValueObjects\ToolContext;
+use Whilesmart\Holdings\Models\Holding;
+
+class HoldingsAiToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_holdings_tool_returns_only_the_users_holdings()
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        Holding::create(['owner_type' => User::class, 'owner_id' => $user->id, 'name' => 'Bitcoin', 'quantity' => 0.5, 'unit_price' => 60000, 'currency' => 'USD']);
+        Holding::create(['owner_type' => User::class, 'owner_id' => $other->id, 'name' => 'Theirs', 'quantity' => 1, 'unit_price' => 1, 'currency' => 'USD']);
+
+        $result = app(ListHoldingsTool::class)->handle([], ToolContext::forUser($user, 'en'));
+
+        $this->assertCount(1, $result['holdings']);
+        $this->assertEquals('Bitcoin', $result['holdings'][0]['name']);
+        $this->assertEquals(30000, $result['holdings'][0]['value']);
+    }
+
+    public function test_get_stats_tool_exposes_the_position_section()
+    {
+        $user = User::factory()->create();
+        Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000, 'currency' => 'USD']);
+        Holding::create(['owner_type' => User::class, 'owner_id' => $user->id, 'name' => 'Bitcoin', 'quantity' => 2, 'unit_price' => 500, 'currency' => 'USD']);
+
+        $result = app(GetStatsTool::class)->handle(['section' => 'position'], ToolContext::forUser($user, 'en'));
+
+        $this->assertArrayHasKey('position', $result);
+        $this->assertEquals(1000, $result['position']['cash_balance']);
+        $this->assertEquals(1000, $result['position']['holdings_value']); // 2 * 500
+        $this->assertEquals(2000, $result['position']['total_net_worth']);
+    }
+}

--- a/tests/Feature/HoldingsIntegrationTest.php
+++ b/tests/Feature/HoldingsIntegrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Whilesmart\Holdings\Models\Holding;
+
+class HoldingsIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    private function ownerPayload(array $extra = []): array
+    {
+        return array_merge([
+            'owner_type' => User::class,
+            'owner_id' => $this->user->id,
+            'name' => 'Bitcoin',
+            'quantity' => 0.5,
+            'currency' => 'USD',
+            'unit_price' => 60000,
+            'price_source' => 'manual',
+        ], $extra);
+    }
+
+    public function test_user_creates_a_holding_via_the_package_route()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/holdings', $this->ownerPayload());
+
+        $response->assertStatus(201);
+        $this->assertEquals(30000, $response->json('data.value')); // 0.5 * 60000
+        $this->assertDatabaseHas('holdings', [
+            'owner_type' => User::class,
+            'owner_id' => $this->user->id,
+            'name' => 'Bitcoin',
+        ]);
+    }
+
+    public function test_index_is_scoped_to_the_authenticated_user()
+    {
+        Holding::create($this->ownerPayload(['name' => 'Mine']));
+        $other = User::factory()->create();
+        Holding::create(['owner_type' => User::class, 'owner_id' => $other->id, 'name' => 'Theirs', 'quantity' => 1, 'unit_price' => 1, 'currency' => 'USD']);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/holdings');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data.data'))->pluck('name')->all();
+        $this->assertContains('Mine', $names);
+        $this->assertNotContains('Theirs', $names);
+    }
+
+    public function test_creating_for_another_owner_is_forbidden()
+    {
+        $other = User::factory()->create();
+
+        $this->actingAs($this->user)
+            ->postJson('/api/v1/holdings', $this->ownerPayload(['owner_id' => $other->id]))
+            ->assertStatus(403);
+    }
+
+    public function test_reprice_updates_auto_holdings_via_coingecko()
+    {
+        Http::fake([
+            'api.coingecko.com/api/v3/simple/price*' => Http::response(['bitcoin' => ['usd' => 70000]], 200),
+        ]);
+
+        $holding = Holding::create($this->ownerPayload([
+            'name' => 'Bitcoin', 'unit_price' => 1, 'price_source' => 'auto', 'provider' => 'coingecko', 'external_ref' => 'bitcoin',
+        ]));
+
+        $this->actingAs($this->user)->postJson('/api/v1/holdings/reprice')->assertStatus(200);
+
+        $this->assertEquals(70000, $holding->fresh()->unit_price);
+    }
+
+    public function test_asset_price_search_proxies_coingecko()
+    {
+        Http::fake([
+            'api.coingecko.com/api/v3/search*' => Http::response([
+                'coins' => [['id' => 'bitcoin', 'name' => 'Bitcoin', 'symbol' => 'btc']],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/asset-prices/search?q=bitcoin');
+
+        $response->assertStatus(200);
+        $this->assertEquals('bitcoin', $response->json('data.0.id'));
+        $this->assertEquals('BTC', $response->json('data.0.symbol'));
+    }
+}

--- a/tests/Feature/StatsControllerTest.php
+++ b/tests/Feature/StatsControllerTest.php
@@ -143,6 +143,75 @@ class StatsControllerTest extends TestCase
     }
 
     /** @test */
+    public function it_includes_cash_and_holdings_in_total_net_worth(): void
+    {
+        Wallet::factory()->create(['user_id' => $this->user->id, 'balance' => 1000, 'currency' => 'USD']);
+        \Whilesmart\Holdings\Models\Holding::create([
+            'owner_type' => \App\Models\User::class,
+            'owner_id' => $this->user->id,
+            'name' => 'Bitcoin',
+            'quantity' => 2, 'unit_price' => 500, 'currency' => 'USD',
+        ]);
+
+        $response = $this->withHeaders(['Authorization' => 'Bearer '.$this->token])
+            ->getJson('/api/v1/stats?preset=all_time&section=position');
+
+        $response->assertStatus(200);
+        $position = $response->json('data.position');
+        $this->assertEquals(1000, $position['cash_balance']);
+        $this->assertEquals(1000, $position['holdings_value']); // 2 * 500
+        $this->assertEquals(2000, $position['total_net_worth']);
+    }
+
+    /** @test */
+    public function it_computes_financial_position_separating_intents(): void
+    {
+        $wallet = Wallet::factory()->create(['user_id' => $this->user->id, 'balance' => 1000]);
+
+        $cases = [
+            ['income', 'regular', 5000],
+            ['expense', 'regular', 500],
+            ['income', 'loan_received', 3000],
+            ['expense', 'loan_repayment', 1000],
+            ['expense', 'investment_buy', 2000],
+            ['income', 'investment_return', 400],
+            ['income', 'gift', 100],
+        ];
+
+        foreach ($cases as [$type, $intent, $amount]) {
+            Transaction::factory()->create([
+                'user_id' => $this->user->id,
+                'wallet_id' => $wallet->id,
+                'type' => $type,
+                'intent' => $intent,
+                'amount' => $amount,
+                'datetime' => Carbon::now()->subHours(2),
+            ]);
+        }
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$this->token,
+        ])->getJson('/api/v1/stats?preset=all_time&section=position');
+
+        $response->assertStatus(200);
+
+        $position = $response->json('data.position');
+        $this->assertEquals(5000, $position['earned_income']); // excludes loan, gift, investment return
+        $this->assertEquals(500, $position['discretionary_spend']); // excludes loan repayment, investment buy
+        $this->assertEquals(3000, $position['loan_received']);
+        $this->assertEquals(1000, $position['loan_repayment']);
+        $this->assertEquals(0, $position['debt_owed']);
+        $this->assertEquals(0, $position['debt_settled']);
+        $this->assertEquals(2000, $position['loans_debt_net']); // 3000 received - 1000 repaid
+        $this->assertEquals(2000, $position['investment_principal']);
+        $this->assertEquals(400, $position['investment_returns']);
+        $this->assertEquals(100, $position['gifts_received']);
+        // Net worth excludes investment principal (cash converted to an asset)
+        // and loan/debt movement (balance-neutral): 5000 - 500 + 400 + 100.
+        $this->assertEquals(5000, $position['net_worth_delta']);
+    }
+
+    /** @test */
     public function it_calculates_correct_totals(): void
     {
         $this->createTestData();

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -34,6 +34,135 @@ class TransactionsTest extends TestCase
         $this->assertDatabaseHas('transactions', ['id' => $income['id']]);
     }
 
+    public function test_transaction_intent_defaults_to_regular()
+    {
+        $income = $this->createTransaction('income');
+
+        $this->assertEquals('regular', $income['intent']);
+        $this->assertDatabaseHas('transactions', ['id' => $income['id'], 'intent' => 'regular']);
+    }
+
+    public function test_api_user_can_create_transaction_with_intent()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'income',
+            'amount' => 5000,
+            'wallet_id' => $this->wallet->id,
+            'intent' => 'loan_received',
+            'datetime' => '2025-04-30T15:17:54.120Z',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertEquals('loan_received', $response->json('data.intent'));
+        $this->assertDatabaseHas('transactions', [
+            'id' => $response->json('data.id'),
+            'intent' => 'loan_received',
+        ]);
+    }
+
+    public function test_api_user_can_update_transaction_intent()
+    {
+        $income = $this->createTransaction('income');
+
+        $response = $this->actingAs($this->user)->putJson('/api/v1/transactions/' . $income['id'], [
+            'intent' => 'investment_return',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('transactions', [
+            'id' => $income['id'],
+            'intent' => 'investment_return',
+        ]);
+    }
+
+    public function test_index_filters_by_intent()
+    {
+        $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'income', 'amount' => 5000, 'wallet_id' => $this->wallet->id,
+            'intent' => 'investment_return', 'datetime' => '2025-04-30T15:17:54.120Z',
+        ]);
+        $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense', 'amount' => 2000, 'wallet_id' => $this->wallet->id,
+            'intent' => 'investment_buy', 'datetime' => '2025-04-30T15:17:54.120Z',
+        ]);
+        $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense', 'amount' => 30, 'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/v1/transactions?intent=investment_buy,investment_return');
+
+        $response->assertStatus(200);
+        $intents = collect($response->json('data.data'))->pluck('intent')->all();
+        $this->assertEqualsCanonicalizing(['investment_return', 'investment_buy'], $intents);
+    }
+
+    public function test_index_can_exclude_transfers()
+    {
+        $regular = $this->createTransaction('income');
+        $transfer = \App\Models\Transfer::factory()->create([
+            'user_id' => $this->user->id,
+            'from_wallet_id' => $this->wallet->id,
+            'to_wallet_id' => $this->wallet->id,
+        ]);
+        $transferLeg = $this->user->transactions()->create([
+            'type' => 'income',
+            'amount' => 999,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => now(),
+            'transfer_id' => $transfer->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/v1/transactions?intent=regular&type=income&exclude_transfers=1');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.data'))->pluck('id')->all();
+        $this->assertContains($regular['id'], $ids);
+        $this->assertNotContains($transferLeg->id, $ids);
+    }
+
+    public function test_index_filters_by_comma_separated_wallet_ids()
+    {
+        $secondWallet = $this->user->wallets()->create(['name' => 'Second', 'balance' => 0]);
+        $thirdWallet = $this->user->wallets()->create(['name' => 'Third', 'balance' => 0]);
+
+        $inFirst = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'income', 'amount' => 10, 'wallet_id' => $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+        ])->json('data.id');
+        $inSecond = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'income', 'amount' => 20, 'wallet_id' => $secondWallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+        ])->json('data.id');
+        $inThird = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'income', 'amount' => 30, 'wallet_id' => $thirdWallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+        ])->json('data.id');
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/v1/transactions?wallet_ids={$this->wallet->id},{$secondWallet->id}");
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data.data'))->pluck('id')->all();
+        $this->assertEqualsCanonicalizing([$inFirst, $inSecond], $ids);
+        $this->assertNotContains($inThird, $ids);
+    }
+
+    public function test_invalid_intent_is_rejected()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'income',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'intent' => 'not_a_real_intent',
+            'datetime' => '2025-04-30T15:17:54.120Z',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
     private function createTransaction(string $type, array $recurrentData = []): array
     {
         $data = [


### PR DESCRIPTION
## What
- **Transaction intent.** Each transaction carries an `intent` (regular, loan received/repaid, debt owed/settled, investment buy/return, gift) so borrowed money and asset moves aren't counted as earnings or spending. Defaults to `regular`; untagged data is unaffected.
- **Financial Position.** A `position` stats section returns net worth plus a money in / money out breakdown by intent, separating real earnings and spend from balance-neutral movement (loans, debt) and asset conversion (investments).
- **Asset holdings.** Holdings now come from the `whilesmart/eloquent-holdings` package, owner-scoped to the user via a bound `OwnerAuthorizer` and priced live through a CoinGecko adapter. Holdings value feeds net worth. The in-app holdings table/model/controller were removed in favour of the package.
- **Assistant.** The stats tool gains the `position` section, a `list_holdings` read tool is added, and `smartql.yml` learns the `holdings` table and the `intent` column.
- **Convention.** `AGENTS.md` records that new user-facing models ship with their AI tools and smartql entries.

## Why
- Naive income/expense totals misrepresent reality: a loan inflates income, an investment looks like spending. Intent fixes the classification; Financial Position surfaces honest net worth.
- Holdings is a reusable concern, so it lives in a standalone package the app consumes.

## Notes
- Adds `whilesmart/eloquent-holdings` and `eloquent-owner-access` to composer; OpenAPI spec regenerated.

## Tests
- 647 passing: intent persistence/filtering, the position section, holdings CRUD with owner authorization, the CoinGecko reprice path, and the new AI tools.
