### PR TITLE
feat(currency): Expose rate/price APIs and correct budget conversion

### DIFF
--- a/app/Ai/Harnesses/TrakliHarness.php
+++ b/app/Ai/Harnesses/TrakliHarness.php
@@ -110,6 +110,8 @@ PROMPT;
             'list_wallets',
             'list_categories',
             'list_parties',
+            'get_exchange_rate',
+            'get_asset_price',
             'render_kpi',
             'render_chart',
             'render_table',

--- a/app/Ai/Tools/Read/GetAssetPriceTool.php
+++ b/app/Ai/Tools/Read/GetAssetPriceTool.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Ai\Tools\Read;
+
+use App\Services\AssetPriceService;
+use Whilesmart\Agents\Enums\ParameterType;
+use Whilesmart\Agents\Enums\ToolPermission;
+use Whilesmart\Agents\Tools\AbstractTool;
+use Whilesmart\Agents\ValueObjects\ParameterSpec;
+use Whilesmart\Agents\ValueObjects\ToolContext;
+
+/**
+ * Looks up live asset prices from the same CoinGecko feed the server uses. Pass
+ * `query` to resolve a coin name to its id, then `ids` to fetch current prices.
+ * Use it to value holdings; never invent a price.
+ */
+class GetAssetPriceTool extends AbstractTool
+{
+    public function __construct(private AssetPriceService $assetPrices)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'get_asset_price';
+    }
+
+    public function description(): string
+    {
+        return 'Look up live crypto/asset prices. Pass "query" (a coin name or symbol) to '
+            . 'find its CoinGecko id, and/or "ids" to fetch current prices in a fiat '
+            . 'currency. Returns authoritative prices; never invent figures.';
+    }
+
+    public function parameters(): array
+    {
+        return [
+            ParameterSpec::string('query', 'Coin name or symbol to resolve to a CoinGecko id, e.g. "bitcoin".', required: false),
+            ParameterSpec::arrayOf('ids', 'CoinGecko coin ids to price, e.g. ["bitcoin", "ethereum"].', ParameterType::STRING, required: false),
+            ParameterSpec::string('vs_currency', 'Fiat currency for prices. Defaults to "usd".', required: false),
+        ];
+    }
+
+    public function permission(): ToolPermission
+    {
+        return ToolPermission::READ;
+    }
+
+    /** @SuppressWarnings(PHPMD.UnusedFormalParameter) */
+    public function handle(array $arguments, ToolContext $context): string|array
+    {
+        $query = trim((string) ($arguments['query'] ?? ''));
+        $ids = collect($arguments['ids'] ?? [])
+            ->map(fn ($id) => trim((string) $id))
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($query === '' && $ids === []) {
+            return ['error' => 'Provide a "query" to look up a coin, or "ids" to price coins.'];
+        }
+
+        $result = [];
+
+        if ($query !== '') {
+            $result['matches'] = $this->assetPrices->searchCoins($query);
+        }
+
+        if ($ids !== []) {
+            $vsCurrency = (string) ($arguments['vs_currency'] ?? 'usd');
+            $result['vs_currency'] = strtolower($vsCurrency);
+            $result['prices'] = $this->assetPrices->fetchPrices($ids, $vsCurrency);
+        }
+
+        return $result;
+    }
+}

--- a/app/Ai/Tools/Read/GetExchangeRateTool.php
+++ b/app/Ai/Tools/Read/GetExchangeRateTool.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Ai\Tools\Read;
+
+use App\Models\User;
+use App\Services\ExchangeRateService;
+use Whilesmart\Agents\Enums\ParameterType;
+use Whilesmart\Agents\Enums\ToolPermission;
+use Whilesmart\Agents\Tools\AbstractTool;
+use Whilesmart\Agents\ValueObjects\ParameterSpec;
+use Whilesmart\Agents\ValueObjects\ToolContext;
+
+/**
+ * Returns current exchange rates from a base currency, honoring the user's
+ * manual rates. Use it to ground any cross-currency figure before answering
+ * so the assistant matches what budgets and stats compute.
+ */
+class GetExchangeRateTool extends AbstractTool
+{
+    public function __construct(private ExchangeRateService $exchangeRates)
+    {
+    }
+
+    public function name(): string
+    {
+        return 'get_exchange_rate';
+    }
+
+    public function description(): string
+    {
+        return 'Get current exchange rates from a base currency to one or more targets. '
+            . 'Honors the user\'s manual exchange rates, so the numbers match budgets and '
+            . 'stats. Returns authoritative rates; never invent or estimate a rate.';
+    }
+
+    public function parameters(): array
+    {
+        return [
+            ParameterSpec::string('base', 'Base currency code, e.g. "USD".'),
+            ParameterSpec::arrayOf('targets', 'Target currency codes to convert into, e.g. ["EUR", "GBP"].', ParameterType::STRING),
+        ];
+    }
+
+    public function permission(): ToolPermission
+    {
+        return ToolPermission::READ;
+    }
+
+    public function handle(array $arguments, ToolContext $context): string|array
+    {
+        $user = $context->user;
+
+        if (! $user instanceof User) {
+            return ['error' => 'No authenticated user in context.'];
+        }
+
+        $base = strtoupper((string) ($arguments['base'] ?? ''));
+        if ($base === '') {
+            return ['error' => 'A base currency is required.'];
+        }
+
+        $targets = collect($arguments['targets'] ?? [])
+            ->map(fn ($code) => strtoupper(trim((string) $code)))
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($targets->isEmpty()) {
+            return ['error' => 'At least one target currency is required.'];
+        }
+
+        $rates = [];
+        $unavailable = [];
+
+        foreach ($targets as $target) {
+            $rate = $this->exchangeRates->getRate($base, $target, $user);
+
+            if ($rate === null) {
+                $unavailable[] = $target;
+
+                continue;
+            }
+
+            $rates[$target] = $rate;
+        }
+
+        return [
+            'base' => $base,
+            'rates' => $rates,
+            'unavailable' => $unavailable,
+        ];
+    }
+}

--- a/app/Http/Controllers/API/v1/AssetPriceController.php
+++ b/app/Http/Controllers/API/v1/AssetPriceController.php
@@ -23,4 +23,61 @@ class AssetPriceController extends ApiController
 
         return $this->success($this->assetPrices->searchCoins((string) $request->query('q')));
     }
+
+    #[OA\Get(
+        path: '/asset-prices',
+        summary: 'Get current prices for assets',
+        description: 'Returns current CoinGecko prices for the given coin ids in the requested '
+            . 'fiat currency, so clients value holdings against the same feed the server uses.',
+        tags: ['Holdings'],
+        parameters: [
+            new OA\Parameter(
+                name: 'ids',
+                description: 'Comma-separated CoinGecko coin ids.',
+                in: 'query',
+                required: true,
+                schema: new OA\Schema(type: 'string', example: 'bitcoin,ethereum')
+            ),
+            new OA\Parameter(
+                name: 'vs_currency',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', default: 'usd', example: 'usd')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Prices retrieved',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'data', properties: [
+                            new OA\Property(property: 'vs_currency', type: 'string', example: 'usd'),
+                            new OA\Property(
+                                property: 'prices',
+                                type: 'object',
+                                example: ['bitcoin' => 65000.0, 'ethereum' => 3200.0]
+                            ),
+                        ], type: 'object'),
+                    ]
+                )
+            ),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
+    public function prices(Request $request): JsonResponse
+    {
+        $request->validate([
+            'ids' => 'required|string|min:1',
+            'vs_currency' => 'sometimes|string|size:3',
+        ]);
+
+        $ids = array_filter(array_map('trim', explode(',', (string) $request->query('ids'))));
+        $vsCurrency = (string) ($request->query('vs_currency') ?? 'usd');
+
+        return $this->success([
+            'vs_currency' => strtolower($vsCurrency),
+            'prices' => $this->assetPrices->fetchPrices($ids, $vsCurrency),
+        ]);
+    }
 }

--- a/app/Http/Controllers/API/v1/AssetPriceController.php
+++ b/app/Http/Controllers/API/v1/AssetPriceController.php
@@ -62,6 +62,7 @@ class AssetPriceController extends ApiController
                     ]
                 )
             ),
+            new OA\Response(response: 401, description: 'Unauthenticated'),
             new OA\Response(response: 422, description: 'Validation error'),
         ]
     )]

--- a/app/Http/Controllers/API/v1/ExchangeRateController.php
+++ b/app/Http/Controllers/API/v1/ExchangeRateController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Http\Controllers\API\ApiController;
+use App\Services\ExchangeRateService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+
+#[OA\Tag(name: 'Currency', description: 'Exchange rates and asset prices')]
+class ExchangeRateController extends ApiController
+{
+    public function __construct(protected ExchangeRateService $exchangeRates)
+    {
+    }
+
+    #[OA\Get(
+        path: '/exchange-rates',
+        summary: 'Get current exchange rates from a base currency',
+        description: 'Returns rates from the base currency to each requested target, '
+            . 'honoring the authenticated user\'s manual exchange rates. Targets with no '
+            . 'available rate are listed under "unavailable" rather than returned as a rate.',
+        tags: ['Currency'],
+        parameters: [
+            new OA\Parameter(
+                name: 'base',
+                in: 'query',
+                required: true,
+                schema: new OA\Schema(type: 'string', example: 'USD')
+            ),
+            new OA\Parameter(
+                name: 'targets',
+                description: 'Comma-separated target currency codes. Use this or "target".',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', example: 'EUR,GBP,JPY')
+            ),
+            new OA\Parameter(
+                name: 'target',
+                description: 'A single target currency code. Use this or "targets".',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', example: 'EUR')
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Rates retrieved',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'data', properties: [
+                            new OA\Property(property: 'base', type: 'string', example: 'USD'),
+                            new OA\Property(
+                                property: 'rates',
+                                type: 'object',
+                                example: ['EUR' => 0.92, 'GBP' => 0.79]
+                            ),
+                            new OA\Property(
+                                property: 'unavailable',
+                                type: 'array',
+                                items: new OA\Items(type: 'string'),
+                                example: ['JPY']
+                            ),
+                        ], type: 'object'),
+                    ]
+                )
+            ),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ]
+    )]
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'base' => ['required', 'string', 'size:3'],
+            'targets' => ['required_without:target', 'string'],
+            'target' => ['required_without:targets', 'string', 'size:3'],
+        ]);
+
+        $base = strtoupper($validated['base']);
+
+        $targets = collect(explode(',', $validated['targets'] ?? $validated['target']))
+            ->map(fn ($code) => strtoupper(trim($code)))
+            ->filter()
+            ->unique()
+            ->values();
+
+        $rates = [];
+        $unavailable = [];
+
+        foreach ($targets as $target) {
+            $rate = $this->exchangeRates->getRate($base, $target, $request->user());
+
+            if ($rate === null) {
+                $unavailable[] = $target;
+
+                continue;
+            }
+
+            $rates[$target] = $rate;
+        }
+
+        return $this->success([
+            'base' => $base,
+            'rates' => $rates,
+            'unavailable' => $unavailable,
+        ]);
+    }
+}

--- a/app/Http/Controllers/API/v1/ExchangeRateController.php
+++ b/app/Http/Controllers/API/v1/ExchangeRateController.php
@@ -67,6 +67,7 @@ class ExchangeRateController extends ApiController
                     ]
                 )
             ),
+            new OA\Response(response: 401, description: 'Unauthenticated'),
             new OA\Response(response: 422, description: 'Validation error'),
         ]
     )]

--- a/app/Services/BudgetProgressService.php
+++ b/app/Services/BudgetProgressService.php
@@ -6,6 +6,7 @@ use App\Contracts\OwnerResolver;
 use App\Models\Budget;
 use App\Models\BudgetPeriodState;
 use App\Models\Transaction;
+use App\Models\User;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
@@ -19,6 +20,21 @@ class BudgetProgressService
     public const STATUS_OVER_BUDGET = 'over_budget';
 
     public const STATUS_FORECAST_BREACH = 'forecast_breach';
+
+    /**
+     * Owner whose manual exchange rates apply while converting this budget's
+     * spend. Set per compute() run; null when the owner is not a single user.
+     */
+    private ?User $convertUser = null;
+
+    /**
+     * Currencies encountered with no available rate during the current
+     * compute() run. A non-empty set flags the snapshot partial instead of
+     * silently counting unconverted spend as zero.
+     *
+     * @var array<string, true>
+     */
+    private array $unconvertedCurrencies = [];
 
     public function __construct(
         protected OwnerResolver $ownerResolver,
@@ -55,6 +71,9 @@ class BudgetProgressService
             : CarbonImmutable::now();
 
         [$periodStart, $periodEnd] = $this->resolvePeriodWindow($budget, $reference);
+
+        $this->convertUser = $budget->owner instanceof User ? $budget->owner : null;
+        $this->unconvertedCurrencies = [];
 
         $userIds = $this->ownerResolver->resolveUserIds($budget->owner);
         $categoryIds = $this->targetIds($budget, 'categories');
@@ -123,7 +142,7 @@ class BudgetProgressService
 
         $status = $this->deriveStatus($netSpent, $effectiveLimit, $thresholdCrossed, $forecastBreach);
 
-        return [
+        $snapshot = [
             'period_start' => $periodStart->toDateString(),
             'period_end' => $periodEnd->toDateString(),
             'limit' => $limit,
@@ -139,6 +158,13 @@ class BudgetProgressService
             'is_threshold_crossed' => $thresholdCrossed,
             'is_forecast_breach' => $forecastBreach,
         ];
+
+        if ($this->unconvertedCurrencies !== []) {
+            $snapshot['partial'] = true;
+            $snapshot['unconverted_currencies'] = array_keys($this->unconvertedCurrencies);
+        }
+
+        return $snapshot;
     }
 
     /**
@@ -248,18 +274,33 @@ class BudgetProgressService
 
     /**
      * Calculates the total transaction amount, taking into account different currencies
-    */
+     */
     private function getReducedSum($query, $targetCurrency): float
     {
         return (float) $query->with('wallet')->cursor()->reduce(function ($carry, Transaction $transaction) use ($targetCurrency) {
-            $amount = $transaction->amount;
+            $walletCurrency = $transaction->wallet->currency;
 
-            if ($transaction->wallet->currency != $targetCurrency) {
-                $exchangeRate = $this->exchangeRateService->getRate($transaction->wallet->currency, $targetCurrency);
-                $amount = $transaction->amount * $exchangeRate;
+            if ($walletCurrency == $targetCurrency) {
+                return $carry + (float) $transaction->amount;
             }
 
-            return $amount + $carry;
+            $converted = $this->exchangeRateService->convert(
+                (float) $transaction->amount,
+                $walletCurrency,
+                $targetCurrency,
+                $this->convertUser,
+            );
+
+            if ($converted === null) {
+                // No rate available: exclude this amount and flag the snapshot
+                // partial, rather than letting amount * null collapse to 0 and
+                // silently under-report budget spend.
+                $this->unconvertedCurrencies[$walletCurrency] = true;
+
+                return $carry;
+            }
+
+            return $carry + (float) $converted;
         }, 0);
     }
 

--- a/config/agents.php
+++ b/config/agents.php
@@ -58,6 +58,8 @@ return [
         App\Ai\Tools\Read\ListCategoriesTool::class,
         App\Ai\Tools\Read\ListPartiesTool::class,
         App\Ai\Tools\Read\ListHoldingsTool::class,
+        App\Ai\Tools\Read\GetExchangeRateTool::class,
+        App\Ai\Tools\Read\GetAssetPriceTool::class,
         App\Ai\Tools\Render\RenderKpiTool::class,
         App\Ai\Tools\Render\RenderChartTool::class,
         App\Ai\Tools\Render\RenderTableTool::class,

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -762,6 +762,9 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
                     "422": {
                         "description": "Validation error"
                     }
@@ -1707,6 +1710,9 @@
                                 }
                             }
                         }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
                     },
                     "422": {
                         "description": "Validation error"

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -703,6 +703,71 @@
                 }
             }
         },
+        "/asset-prices": {
+            "get": {
+                "tags": [
+                    "Holdings"
+                ],
+                "summary": "Get current prices for assets",
+                "description": "Returns current CoinGecko prices for the given coin ids in the requested fiat currency, so clients value holdings against the same feed the server uses.",
+                "operationId": "f2fdfd5f7e91557937161fe3e6d2658e",
+                "parameters": [
+                    {
+                        "name": "ids",
+                        "in": "query",
+                        "description": "Comma-separated CoinGecko coin ids.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "bitcoin,ethereum"
+                        }
+                    },
+                    {
+                        "name": "vs_currency",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "usd",
+                            "example": "usd"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Prices retrieved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "vs_currency": {
+                                                    "type": "string",
+                                                    "example": "usd"
+                                                },
+                                                "prices": {
+                                                    "type": "object",
+                                                    "example": {
+                                                        "bitcoin": 65000,
+                                                        "ethereum": 3200
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                }
+            }
+        },
         "/budgets": {
             "get": {
                 "tags": [
@@ -1562,6 +1627,89 @@
                     },
                     "500": {
                         "description": "Internal server error"
+                    }
+                }
+            }
+        },
+        "/exchange-rates": {
+            "get": {
+                "tags": [
+                    "Currency"
+                ],
+                "summary": "Get current exchange rates from a base currency",
+                "description": "Returns rates from the base currency to each requested target, honoring the authenticated user's manual exchange rates. Targets with no available rate are listed under \"unavailable\" rather than returned as a rate.",
+                "operationId": "9721eaa414c337abf0fd466303a275e2",
+                "parameters": [
+                    {
+                        "name": "base",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "USD"
+                        }
+                    },
+                    {
+                        "name": "targets",
+                        "in": "query",
+                        "description": "Comma-separated target currency codes. Use this or \"target\".",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "EUR,GBP,JPY"
+                        }
+                    },
+                    {
+                        "name": "target",
+                        "in": "query",
+                        "description": "A single target currency code. Use this or \"targets\".",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "EUR"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Rates retrieved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "base": {
+                                                    "type": "string",
+                                                    "example": "USD"
+                                                },
+                                                "rates": {
+                                                    "type": "object",
+                                                    "example": {
+                                                        "EUR": 0.92,
+                                                        "GBP": 0.79
+                                                    }
+                                                },
+                                                "unavailable": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "example": [
+                                                        "JPY"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error"
                     }
                 }
             }
@@ -6391,6 +6539,10 @@
         {
             "name": "Category",
             "description": "Endpoints for managing transaction categories"
+        },
+        {
+            "name": "Currency",
+            "description": "Exchange rates and asset prices"
         },
         {
             "name": "Files",

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\API\v1\TransactionRefundController;
 use App\Http\Controllers\API\v1\TransferController;
 use App\Http\Controllers\API\v1\UserController;
 use App\Http\Controllers\API\v1\AssetPriceController;
+use App\Http\Controllers\API\v1\ExchangeRateController;
 use App\Http\Controllers\API\v1\WalletController;
 use App\Http\Controllers\API\VersionController;
 use Illuminate\Support\Facades\Route;
@@ -50,6 +51,9 @@ Route::group(['prefix' => 'v1', 'middleware' => ['auth:sanctum']], function () {
         Route::apiResource('transfers', TransferController::class);
 
         Route::get('asset-prices/search', [AssetPriceController::class, 'search']);
+        Route::get('asset-prices', [AssetPriceController::class, 'prices']);
+
+        Route::get('exchange-rates', [ExchangeRateController::class, 'index']);
 
         Route::get('stats', [StatsController::class, 'index']);
     });

--- a/tests/Feature/AssetPriceApiTest.php
+++ b/tests/Feature/AssetPriceApiTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AssetPriceApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_unauthenticated_request_is_rejected(): void
+    {
+        $this->getJson('/api/v1/asset-prices?ids=bitcoin')->assertStatus(401);
+    }
+
+    public function test_returns_prices_for_requested_ids(): void
+    {
+        Http::fake([
+            'api.coingecko.com/api/v3/simple/price*' => Http::response([
+                'bitcoin' => ['usd' => 65000],
+                'ethereum' => ['usd' => 3200],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/v1/asset-prices?ids=bitcoin,ethereum&vs_currency=usd');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.vs_currency', 'usd');
+        $this->assertEqualsWithDelta(65000, $response->json('data.prices.bitcoin'), 0.001);
+        $this->assertEqualsWithDelta(3200, $response->json('data.prices.ethereum'), 0.001);
+    }
+
+    public function test_ids_are_required(): void
+    {
+        $this->actingAs($this->user)->getJson('/api/v1/asset-prices')->assertStatus(422);
+    }
+
+    public function test_coin_search_returns_matches(): void
+    {
+        Http::fake([
+            'api.coingecko.com/api/v3/search*' => Http::response([
+                'coins' => [
+                    ['id' => 'bitcoin', 'name' => 'Bitcoin', 'symbol' => 'btc'],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/asset-prices/search?q=bitcoin');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.0.id', 'bitcoin');
+        $response->assertJsonPath('data.0.symbol', 'BTC');
+    }
+}

--- a/tests/Feature/BudgetTest.php
+++ b/tests/Feature/BudgetTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Events\BudgetThresholdBreached;
 use App\Events\TransactionRecorded;
 use App\Jobs\RecomputeBudgetProgressJob;
+use App\Listeners\CreateBudgetAlertReminder;
 use App\Models\Budget;
 use App\Models\Category;
 use App\Models\Reminder;
@@ -14,8 +15,10 @@ use App\Models\Wallet;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
 
 class BudgetTest extends TestCase
 {
@@ -112,7 +115,7 @@ class BudgetTest extends TestCase
         ]);
         $budget->categories()->attach($category);
 
-        $listener = app(\App\Listeners\CreateBudgetAlertReminder::class);
+        $listener = app(CreateBudgetAlertReminder::class);
         $event = new BudgetThresholdBreached(
             budgetId: $budget->id,
             periodStart: CarbonImmutable::now()->startOfMonth()->toDateString(),
@@ -218,5 +221,63 @@ class BudgetTest extends TestCase
             ->pivot
             ->id;
         $this->assertSame($keepPivotIdBefore, $keepPivotIdAfter);
+    }
+
+    public function test_progress_excludes_unconvertible_spend_and_flags_partial(): void
+    {
+        // No manual rate and no API rate available, so the foreign expense
+        // cannot convert into the budget's currency.
+        Http::fake(['*' => Http::response([], 200)]);
+
+        $budget = Budget::factory()->create([
+            'owner_type' => User::class,
+            'owner_id' => $this->user->id,
+            'currency' => 'USD',
+        ]);
+
+        $eurWallet = Wallet::factory()->create(['user_id' => $this->user->id, 'currency' => 'EUR']);
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $eurWallet->id,
+            'type' => 'expense',
+            'amount' => 100,
+            'datetime' => now(),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/v1/budgets/{$budget->id}/progress");
+
+        $response->assertOk();
+        // The spend is excluded rather than collapsing to 0 silently.
+        $this->assertEqualsWithDelta(0, $response->json('data.gross_spent'), 0.001);
+        $this->assertTrue($response->json('data.partial'));
+        $this->assertContains('EUR', $response->json('data.unconverted_currencies'));
+    }
+
+    public function test_progress_applies_user_manual_exchange_rate(): void
+    {
+        $this->user->setConfigValue('manual-exchange-rates', ['EUR-USD' => 1.1], ConfigValueType::Json);
+
+        $budget = Budget::factory()->create([
+            'owner_type' => User::class,
+            'owner_id' => $this->user->id,
+            'currency' => 'USD',
+        ]);
+
+        $eurWallet = Wallet::factory()->create(['user_id' => $this->user->id, 'currency' => 'EUR']);
+        Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $eurWallet->id,
+            'type' => 'expense',
+            'amount' => 100,
+            'datetime' => now(),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/v1/budgets/{$budget->id}/progress");
+
+        $response->assertOk();
+        // 100 EUR * 1.1 = 110 USD.
+        $this->assertEqualsWithDelta(110, $response->json('data.gross_spent'), 0.001);
+        $this->assertEqualsWithDelta(110, $response->json('data.net_spent'), 0.001);
+        $this->assertArrayNotHasKey('partial', $response->json('data'));
     }
 }

--- a/tests/Feature/ExchangeRateApiTest.php
+++ b/tests/Feature/ExchangeRateApiTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ExchangeRate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+
+class ExchangeRateApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_unauthenticated_request_is_rejected(): void
+    {
+        $this->getJson('/api/v1/exchange-rates?base=USD&target=EUR')->assertStatus(401);
+    }
+
+    public function test_returns_rate_map_for_available_pairs(): void
+    {
+        ExchangeRate::create([
+            'base_currency' => 'USD',
+            'target_currency' => 'EUR',
+            'rate' => 0.9,
+            'fetched_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/exchange-rates?base=USD&targets=EUR');
+
+        $response->assertOk();
+        $response->assertJsonPath('data.base', 'USD');
+        $this->assertEqualsWithDelta(0.9, $response->json('data.rates.EUR'), 0.0001);
+        $this->assertSame([], $response->json('data.unavailable'));
+    }
+
+    public function test_manual_rate_takes_precedence_over_cached_rate(): void
+    {
+        // A cached rate exists, but the user's manual override must win.
+        ExchangeRate::create([
+            'base_currency' => 'USD',
+            'target_currency' => 'EUR',
+            'rate' => 0.9,
+            'fetched_at' => now(),
+        ]);
+        $this->user->setConfigValue('manual-exchange-rates', ['USD-EUR' => 0.5], ConfigValueType::Json);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/exchange-rates?base=USD&target=EUR');
+
+        $response->assertOk();
+        $this->assertEqualsWithDelta(0.5, $response->json('data.rates.EUR'), 0.0001);
+    }
+
+    public function test_targets_with_no_rate_are_listed_as_unavailable(): void
+    {
+        // No cached rate and no API rate available for the pair.
+        Http::fake(['*' => Http::response([], 200)]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/exchange-rates?base=USD&targets=GBP');
+
+        $response->assertOk();
+        $this->assertContains('GBP', $response->json('data.unavailable'));
+        $this->assertArrayNotHasKey('GBP', $response->json('data.rates'));
+    }
+
+    public function test_base_is_required(): void
+    {
+        $this->actingAs($this->user)->getJson('/api/v1/exchange-rates?targets=EUR')->assertStatus(422);
+    }
+}


### PR DESCRIPTION
Closes #268 and #265.

Currency conversion lived only in the backend and was applied inconsistently, so the same transactions could total differently across budgets, stats, and the mobile app, and clients had no way to source the server's rates or prices.

The load-bearing fix is two subtle budget bugs: spend was converted without the user, so a user's manual exchange rates silently never applied (stats already passes the user, so budgets disagreed with it for the same data), and a transaction with a missing rate was counted as zero rather than flagged, hiding the shortfall. Both are corrected, and an unconvertible amount now surfaces as a partial result instead of vanishing into the total.

Everything else follows from making the server the single source of truth for rates and prices, reachable by clients and the assistant.
