### PR TITLE
feat(integrations): Let integrations describe their client UI

### DIFF
--- a/app/Contracts/IntegrationUi.php
+++ b/app/Contracts/IntegrationUi.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * Optional capability an Integration can implement to describe where and how
+ * its UI surfaces in the client, without the client knowing the vendor. The
+ * descriptor is additive metadata: integrations that do not implement this
+ * still list normally, just without a `ui` block.
+ *
+ * Shape of the returned array:
+ *   [
+ *     'slots'      => string[],            // named client slots, e.g. ['settings.integrations']
+ *     'card'       => array|null,          // ['title' => ..., 'cta' => ..., 'description' => ...]
+ *     'connect'    => array|null,          // ['type' => ..., ...type-specific keys]
+ *     'onboarding' => array|null,          // ['step' => ..., 'optional' => bool, 'order' => int]
+ *     'component'  => string|null,         // slot-key a plugin Nuxt layer registered, or null
+ *     'show_when_unconfigured' => bool,    // optional; render with a needs-setup state instead of hiding when not configured
+ *   ]
+ */
+interface IntegrationUi extends Integration
+{
+    /**
+     * @return array<string, mixed>
+     *
+     * @SuppressWarnings(PHPMD.ShortMethodName)
+     */
+    public function ui(): array;
+}

--- a/app/Http/Controllers/API/v1/IntegrationController.php
+++ b/app/Http/Controllers/API/v1/IntegrationController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers\API\v1;
 
+use App\Contracts\Entitlements;
 use App\Contracts\Integration;
+use App\Contracts\IntegrationUi;
 use App\Http\Controllers\API\ApiController;
 use App\Services\IntegrationRegistry;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
 
 #[OA\Tag(name: 'Integration', description: 'Installed integrations')]
@@ -37,6 +40,13 @@ class IntegrationController extends ApiController
                                     new OA\Property(property: 'icon', type: 'string', nullable: true),
                                     new OA\Property(property: 'feature_key', type: 'string', nullable: true),
                                     new OA\Property(property: 'configured', type: 'boolean'),
+                                    new OA\Property(property: 'entitled', type: 'boolean'),
+                                    new OA\Property(
+                                        property: 'ui',
+                                        type: 'object',
+                                        nullable: true,
+                                        description: 'Where and how this integration surfaces in the client. Null when the integration declares no UI.'
+                                    ),
                                 ],
                                 type: 'object'
                             )
@@ -48,17 +58,26 @@ class IntegrationController extends ApiController
             new OA\Response(response: 401, description: 'Unauthorized'),
         ]
     )]
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        $data = array_map(fn (Integration $integration) => [
-            'key' => $integration->key(),
-            'name' => $integration->name(),
-            'description' => $integration->description(),
-            'category' => $integration->category(),
-            'icon' => $integration->icon(),
-            'feature_key' => $integration->featureKey(),
-            'configured' => $integration->isConfigured(),
-        ], $this->registry->all());
+        $user = $request->user();
+        $entitlements = app(Entitlements::class);
+
+        $data = array_map(function (Integration $integration) use ($user, $entitlements) {
+            $featureKey = $integration->featureKey();
+
+            return [
+                'key' => $integration->key(),
+                'name' => $integration->name(),
+                'description' => $integration->description(),
+                'category' => $integration->category(),
+                'icon' => $integration->icon(),
+                'feature_key' => $featureKey,
+                'configured' => $integration->isConfigured(),
+                'entitled' => $featureKey === null || $entitlements->allows($user, $featureKey),
+                'ui' => $integration instanceof IntegrationUi ? $integration->ui() : null,
+            ];
+        }, $this->registry->all());
 
         return $this->success($data);
     }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "whilesmart/laravel-plugin-engine": "^1.0.0",
         "whilesmart/laravel-user-authentication": "^1.0",
         "whilesmart/laravel-user-devices": "^1.0.0",
+        "wikimedia/composer-merge-plugin": "^2.1",
         "zircote/swagger-php": "^5.0"
     },
     "require-dev": {
@@ -96,6 +97,11 @@
     "extra": {
         "laravel": {
             "dont-discover": []
+        },
+        "merge-plugin": {
+            "include": [
+                "plugins/*/composer.json"
+            ]
         }
     },
     "config": {
@@ -104,7 +110,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "wikimedia/composer-merge-plugin": true
         }
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c85505a7c495c855607ee7b6b51847d",
+    "content-hash": "0635fd09d1774c0cfb7dadfafc82e49e",
     "packages": [
         {
             "name": "beste/clock",
@@ -1125,6 +1125,50 @@
             "time": "2025-12-03T09:33:47+00:00"
         },
         {
+            "name": "genkgo/camt",
+            "version": "2.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/genkgo/camt.git",
+                "reference": "56e047d1599854ca34db0ccabce15230fcdd3f16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/genkgo/camt/zipball/56e047d1599854ca34db0ccabce15230fcdd3f16",
+                "reference": "56e047d1599854ca34db0ccabce15230fcdd3f16",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "jschaedl/iban-validation": "^2.5",
+                "moneyphp/money": "^4.6",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "@stable",
+                "phpstan/phpstan": "@stable",
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Genkgo\\Camt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library to read CAMT files (XML containing bank statements).",
+            "support": {
+                "issues": "https://github.com/genkgo/camt/issues",
+                "source": "https://github.com/genkgo/camt/tree/2.10.3"
+            },
+            "time": "2025-08-26T09:01:28+00:00"
+        },
+        {
             "name": "google/auth",
             "version": "v1.50.0",
             "source": {
@@ -2076,6 +2120,65 @@
                 }
             ],
             "time": "2025-08-22T14:27:06+00:00"
+        },
+        {
+            "name": "jschaedl/iban-validation",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jschaedl/iban-validation.git",
+                "reference": "9d8054a6edeeeba676482a054b5f73f4004b6145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jschaedl/iban-validation/zipball/9d8054a6edeeeba676482a054b5f73f4004b6145",
+                "reference": "9d8054a6edeeeba676482a054b5f73f4004b6145",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "symfony/options-resolver": "^5.4|^6|^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "suggest": {
+                "ext-bcmath": "This library makes use of bcmod function, so an installed bcmath extension is recommended."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Iban\\Validation\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Schaedlich",
+                    "email": "mail@janschaedlich.de",
+                    "homepage": "https://www.linkedin.com/in/janschaedlich"
+                }
+            ],
+            "description": "A small library for validating International BankAccount Numbers (IBANs).",
+            "homepage": "https://github.com/jschaedl/iban-validation",
+            "keywords": [
+                "IBAN",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/jschaedl/iban-validation/issues",
+                "source": "https://github.com/jschaedl/iban-validation/tree/v2.7.0"
+            },
+            "time": "2025-12-02T19:33:29+00:00"
         },
         {
             "name": "kreait/firebase-php",
@@ -3577,6 +3680,96 @@
                 }
             ],
             "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "moneyphp/money",
+            "version": "v4.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/moneyphp/money.git",
+                "reference": "d49ee625c6ba79b9d7a228ce153b02fc1032152b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/d49ee625c6ba79b9d7a228ce153b02fc1032152b",
+                "reference": "d49ee625c6ba79b9d7a228ce153b02fc1032152b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cache/taggable-cache": "^1.1.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/instantiator": "^1.5.0 || ^2.0",
+                "ext-gmp": "*",
+                "ext-intl": "*",
+                "florianv/exchanger": "^2.8.1",
+                "florianv/swap": "^4.3.0",
+                "moneyphp/crypto-currencies": "^1.1.0",
+                "moneyphp/iso-currencies": "^3.4",
+                "php-http/message": "^1.16.0",
+                "php-http/mock-client": "^1.6.0",
+                "phpbench/phpbench": "^1.2.5",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1.9",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.9",
+                "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
+                "ticketswap/phpstan-error-formatter": "^1.1"
+            },
+            "suggest": {
+                "ext-gmp": "Calculate without integer limits",
+                "ext-intl": "Format Money objects with intl",
+                "florianv/exchanger": "Exchange rates library for PHP",
+                "florianv/swap": "Exchange rates library for PHP",
+                "psr/cache-implementation": "Used for Currency caching"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Verraes",
+                    "email": "mathias@verraes.net",
+                    "homepage": "http://verraes.net"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Frederik Bosch",
+                    "email": "f.bosch@genkgo.nl"
+                }
+            ],
+            "description": "PHP implementation of Fowler's Money pattern",
+            "homepage": "http://moneyphp.org",
+            "keywords": [
+                "Value Object",
+                "money",
+                "vo"
+            ],
+            "support": {
+                "issues": "https://github.com/moneyphp/money/issues",
+                "source": "https://github.com/moneyphp/money/tree/v4.9.0"
+            },
+            "time": "2026-05-04T20:23:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -6669,6 +6862,77 @@
             "time": "2026-03-30T14:11:46+00:00"
         },
         {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.37.0",
             "source": {
@@ -9101,6 +9365,62 @@
                 "source": "https://github.com/whilesmartphp/laravel-user-devices/tree/v1.0.1"
             },
             "time": "2026-01-28T15:42:43+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1||^2.0",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1||^2.0",
+                "ext-json": "*",
+                "mediawiki/mediawiki-phan-config": "0.11.1",
+                "php-parallel-lint/php-parallel-lint": "~1.3.1",
+                "phpspec/prophecy": "~1.15.0",
+                "phpunit/phpunit": "^8.5||^9.0",
+                "squizlabs/php_codesniffer": "~3.7.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin",
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\Merge\\V2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "support": {
+                "issues": "https://github.com/wikimedia/composer-merge-plugin/issues",
+                "source": "https://github.com/wikimedia/composer-merge-plugin/tree/v2.1.0"
+            },
+            "time": "2023-04-15T19:07:00+00:00"
         },
         {
             "name": "zircote/swagger-php",

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2454,6 +2454,14 @@
                                                     },
                                                     "configured": {
                                                         "type": "boolean"
+                                                    },
+                                                    "entitled": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "ui": {
+                                                        "description": "Where and how this integration surfaces in the client. Null when the integration declares no UI.",
+                                                        "type": "object",
+                                                        "nullable": true
                                                     }
                                                 },
                                                 "type": "object"

--- a/tests/Feature/IntegrationsTest.php
+++ b/tests/Feature/IntegrationsTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Contracts\Entitlements;
 use App\Contracts\Integration;
+use App\Contracts\IntegrationUi;
 use App\Models\User;
 use App\Services\IntegrationRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,7 +24,37 @@ class IntegrationsTest extends TestCase
             ->assertJsonPath('data.0.key', 'plaid')
             ->assertJsonPath('data.0.category', 'bank-sync')
             ->assertJsonPath('data.0.feature_key', 'plaid')
-            ->assertJsonPath('data.0.configured', true);
+            ->assertJsonPath('data.0.configured', true)
+            ->assertJsonPath('data.0.entitled', true)
+            ->assertJsonPath('data.0.ui', null);
+    }
+
+    public function test_exposes_ui_descriptor_for_ui_integrations(): void
+    {
+        app(IntegrationRegistry::class)->register($this->fakeUiIntegration());
+
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/integrations')
+            ->assertOk()
+            ->assertJsonPath('data.0.key', 'statement-import')
+            ->assertJsonPath('data.0.ui.slots', ['settings.integrations', 'onboarding.steps'])
+            ->assertJsonPath('data.0.ui.card.cta', 'Import')
+            ->assertJsonPath('data.0.ui.onboarding.order', 60)
+            ->assertJsonPath('data.0.ui.component', null);
+    }
+
+    public function test_entitled_reflects_entitlements_for_gated_integration(): void
+    {
+        app(IntegrationRegistry::class)->register($this->fakeIntegration());
+
+        $this->mock(Entitlements::class, function ($mock) {
+            $mock->shouldReceive('allows')->andReturnFalse();
+        });
+
+        $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/integrations')
+            ->assertOk()
+            ->assertJsonPath('data.0.entitled', false);
     }
 
     public function test_returns_empty_list_when_nothing_registered(): void
@@ -74,6 +106,57 @@ class IntegrationsTest extends TestCase
             public function isConfigured(): bool
             {
                 return true;
+            }
+        };
+    }
+
+    private function fakeUiIntegration(): IntegrationUi
+    {
+        return new class () implements IntegrationUi {
+            public function key(): string
+            {
+                return 'statement-import';
+            }
+
+            public function name(): string
+            {
+                return 'Statement Import';
+            }
+
+            public function description(): ?string
+            {
+                return 'Import bank statements';
+            }
+
+            public function category(): string
+            {
+                return 'import';
+            }
+
+            public function icon(): ?string
+            {
+                return null;
+            }
+
+            public function featureKey(): ?string
+            {
+                return null;
+            }
+
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+
+            public function ui(): array
+            {
+                return [
+                    'slots' => ['settings.integrations', 'onboarding.steps'],
+                    'card' => ['title' => 'Import bank statements', 'cta' => 'Import', 'description' => 'Upload a statement'],
+                    'connect' => null,
+                    'onboarding' => ['step' => 'import-statement', 'optional' => true, 'order' => 60],
+                    'component' => null,
+                ];
             }
         };
     }

--- a/tests/Feature/IntegrationsTest.php
+++ b/tests/Feature/IntegrationsTest.php
@@ -14,6 +14,17 @@ class IntegrationsTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The registry is a boot-populated singleton; enabled plugins register
+        // into it. Start each test from a clean registry so assertions are
+        // deterministic regardless of which plugins are installed.
+        $this->app->forgetInstance(IntegrationRegistry::class);
+        $this->app->singleton(IntegrationRegistry::class);
+    }
+
     public function test_lists_registered_integrations(): void
     {
         app(IntegrationRegistry::class)->register($this->fakeIntegration());

--- a/tests/Feature/StatementImportPluginTest.php
+++ b/tests/Feature/StatementImportPluginTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Contracts\IntegrationUi;
+use App\Enums\TransactionType;
+use App\Models\User;
+use App\Services\DocumentProcessorManager;
+use App\Services\IntegrationRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+use Trakli\StatementImport\StatementImportServiceProvider;
+
+class StatementImportPluginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The statement-import plugin is an embedded plugin, not part of the
+        // core source tree, so skip when it is not installed.
+        if (! class_exists(StatementImportServiceProvider::class)) {
+            $this->markTestSkipped('statement-import plugin is not installed.');
+        }
+
+        // The plugin ships disabled; boot it explicitly so the test exercises
+        // the same registration its service provider performs when enabled.
+        (new StatementImportServiceProvider($this->app))->boot();
+    }
+
+    public function test_it_registers_a_ui_integration(): void
+    {
+        $integration = app(IntegrationRegistry::class)->get('statement-import');
+
+        $this->assertInstanceOf(IntegrationUi::class, $integration);
+        $this->assertContains('settings.integrations', $integration->ui()['slots']);
+        $this->assertContains('onboarding.steps', $integration->ui()['slots']);
+    }
+
+    public function test_it_turns_a_camt_statement_into_transaction_suggestions(): void
+    {
+        $manager = app(DocumentProcessorManager::class);
+
+        $processor = $manager->getProcessor('application/xml', 'xml');
+
+        $file = new UploadedFile(
+            base_path('tests/Fixtures/camt053.minimal.xml'),
+            'statement.xml',
+            'application/xml',
+            null,
+            true
+        );
+
+        $suggestions = $processor->process($file, User::factory()->create());
+
+        $this->assertCount(1, $suggestions);
+
+        $suggestion = $suggestions[0];
+        $this->assertSame(8.85, $suggestion->amount);
+        $this->assertSame('EUR', $suggestion->currency);
+        $this->assertSame(TransactionType::INCOME->value, $suggestion->type);
+        $this->assertSame('2014-12-31', $suggestion->date);
+        $this->assertSame('camt', $suggestion->documentType);
+    }
+}

--- a/tests/Fixtures/camt053.minimal.xml
+++ b/tests/Fixtures/camt053.minimal.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>CAMT053RIB000000000001</MsgId>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+            <MsgRcpt>
+                <Nm>COMPANY BVBA</Nm>
+                <PstlAdr>
+                    <StrtNm>12 Oxford Street</StrtNm>
+                    <Ctry>UK</Ctry>
+                </PstlAdr>
+                <Id>
+                    <OrgId>
+                        <BICOrBEI>DABAIE2D</BICOrBEI>
+                        <Othr>
+                            <Id>Some other Id</Id>
+                            <Issr>Some other Issuer</Issr>
+                        </Othr>
+                    </OrgId>
+                </Id>
+                <CtryOfRes>NL</CtryOfRes>
+            </MsgRcpt>
+            <AddtlInf>Group header additional information</AddtlInf>
+        </GrpHdr>
+        <Stmt>
+            <Id>253EURNL26VAYB8060476890</Id>
+            <ElctrncSeqNb>12312</ElctrncSeqNb>
+            <LglSeqNb>12312</LglSeqNb>
+            <CreDtTm>2015-03-10T18:43:50+00:00</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2007-10-18T08:00:00+01:00</FrDtTm>
+                <ToDtTm>2007-10-18T12:30:00+01:00</ToDtTm>
+            </FrToDt>
+            <CpyDplctInd>CODU</CpyDplctInd>
+            <Acct>
+                <Id>
+                    <IBAN>NL26VAYB8060476890</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">18.15</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-30</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="SEK">27.00</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-12-31</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="EUR">8.85</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <RvslInd>false</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-12-31</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2015-01-02</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>544</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <Prtry>
+                                <Tp>LegalSequenceNumber</Tp>
+                                <Ref>100</Ref>
+                            </Prtry>
+                        </Refs>
+                        <BkTxCd>
+                            <Prtry>
+                                <Cd>544</Cd>
+                            </Prtry>
+                        </BkTxCd>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>NAME NAME</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                    <AdrLine>ADDR ADDR 10</AdrLine>
+                                    <AdrLine>2000 ANTWERPEN</AdrLine>
+                                </PstlAdr>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>NL56AGDH9619008421</IBAN>
+                                </Id>
+                            </DbtrAcct>
+                            <Cdtr>
+                                <Nm>Company Name</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                                <Id>
+                                    <OrgId>
+                                        <Othr>
+                                            <Id>455454654</Id>
+                                            <Issr>KBO-BCE</Issr>
+                                        </Othr>
+                                    </OrgId>
+                                </Id>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL56AGDH9619008421</IBAN>
+                                </Id>
+                                <Ccy>EUR</Ccy>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RmtInf>
+                            <Strd>
+                                <CdtrRefInf>
+                                    <Tp>
+                                        <CdOrPrtry>
+                                            <Cd>SCOR</Cd>
+                                        </CdOrPrtry>
+                                        <Issr>BBA</Issr>
+                                    </Tp>
+                                    <Ref>4654654654654654</Ref>
+                                </CdtrRefInf>
+                            </Strd>
+                        </RmtInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+            <AddtlStmtInf>Additional Information</AddtlStmtInf>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>


### PR DESCRIPTION
Closes #270. Part of the plugin-UI extensibility work.

A backend plugin can register an integration, but the client couldn't tell where that integration's UI belongs or whether the user is allowed to see it, so every plugin needed a hand-edit to core UI. This adds an additive `ui` descriptor and a resolved `entitled` flag to the integrations endpoint, making it the source of truth for placement, gating, and ordering.

Two decisions worth flagging for review:
- The descriptor is a separate `IntegrationUi` marker interface, not a method on the base `Integration` contract, so nothing existing breaks and integrations that don't opt in return `ui: null`.
- Entitlement is resolved server-side and returned per integration; the client honors the boolean instead of deciding paid versus free. With the default allow-all entitlements it's a no-op today.

Also adopts `wikimedia/composer-merge-plugin` so a plugin embedded under `plugins/` resolves its own composer dependencies into the host vendor tree, with a real CAMT.053 fixture and tests exercising the path end to end (the plugin test skips when the plugin isn't installed). The plugin source lives in its own repo; this carries only the host wiring and tests.
