### PR TITLE
fix: Return a consistent response envelope for holdings and stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,37 @@
 # AGENTS.md
 
-Conventions for keeping the AI assistant in sync with the data model. The
-assistant can only see and act on what we expose to it, so adding a model
-without tools leaves a feature the AI is blind to.
+Conventions for changing the Trakli backend. See `CLAUDE.md` for the wider
+project map.
+
+## Rule: API responses use one envelope
+
+Every response an API controller returns goes through the shared envelope. Do
+not return a bare `response()->json([...])`.
+
+- Success: `{ success, message, data }` via `$this->success($data, $message, $status)`.
+- Failure: `{ success, message, errors }` via `$this->failure($message, $status, $errors)`.
+- Lists: the flat pagination shape (`data: { data: [...], current_page, last_page, per_page, total }`)
+  built by `applyApiQuery()` in `app/Http/Traits/ApiQueryable.php`. Never expose Laravel's
+  `links`/`meta` resource-collection wrapper.
+
+Controllers extend `ApiController`, which provides `success()`/`failure()`. The envelope is
+defined once in the response formatter (`config('user-authentication.response_formatter')`),
+so shape it there, not inline per controller.
+
+A reusable package must not hardcode its response shape. Expose a formatter the host app can
+bind, the way `laravel-user-authentication` and `eloquent-holdings` do, then bind Trakli's own
+formatter so the package's responses match this envelope.
+
+Why it is a hard rule: the mobile and web clients parse `success`, `message`, and the flat
+pagination keys as required fields. A response missing any of them does not degrade, it
+crashes the client.
 
 ## Rule: new user-facing models ship with AI access
 
-When you add an Eloquent model / table that holds user data (or a meaningful new
-field on one), in the same change also do the following.
+The assistant can only see and act on what we expose to it, so adding a model
+without tools leaves a feature the AI is blind to. When you add an Eloquent
+model / table that holds user data (or a meaningful new field on one), in the
+same change also do the following.
 
 ### 1. Read tool
 

--- a/app/Holdings/TrakliHoldingResponseFormatter.php
+++ b/app/Holdings/TrakliHoldingResponseFormatter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Holdings;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
+use Whilesmart\Holdings\ResponseFormatters\DefaultResponseFormatter;
+
+class TrakliHoldingResponseFormatter extends DefaultResponseFormatter
+{
+    public function success(mixed $data = null, string $message = 'Operation successful', int $statusCode = 200): JsonResponse
+    {
+        return parent::success($data, __($message), $statusCode);
+    }
+
+    public function failure(string $message = 'Operation failed', int $statusCode = 400, array $errors = []): JsonResponse
+    {
+        return parent::failure(__($message), $statusCode, $errors);
+    }
+
+    public function paginated(LengthAwarePaginator $paginator, string $resourceClass, string $message = 'Operation successful'): JsonResponse
+    {
+        return parent::paginated($paginator, $resourceClass, __($message));
+    }
+}

--- a/app/Http/Controllers/API/v1/StatsController.php
+++ b/app/Http/Controllers/API/v1/StatsController.php
@@ -117,11 +117,10 @@ class StatsController extends ApiController
 
         $section = $request->input('section');
         if ($section !== null && ! in_array($section, StatsService::SECTIONS, true)) {
-            return response()->json([
-                'message' => __('Invalid stats section.'),
+            return $this->failure(__('Invalid stats section.'), 422, [
                 'invalid_section' => $section,
                 'valid_sections' => StatsService::SECTIONS,
-            ], 422);
+            ]);
         }
 
         $cacheKey = StatsService::generateCacheKey(
@@ -147,7 +146,7 @@ class StatsController extends ApiController
             )
         );
 
-        return response()->json(['data' => $data]);
+        return $this->success($data);
     }
 
     private function resolveDateRange(Request $request): array
@@ -195,10 +194,9 @@ class StatsController extends ApiController
 
         $invalidWalletIds = array_diff($walletIds, $validWalletIds);
         if (! empty($invalidWalletIds)) {
-            return response()->json([
-                'message' => __('One or more wallet IDs are invalid or do not belong to the user.'),
+            return $this->failure(__('One or more wallet IDs are invalid or do not belong to the user.'), 422, [
                 'invalid_wallet_ids' => array_values($invalidWalletIds),
-            ], 422);
+            ]);
         }
 
         return $walletIds;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "whilesmart/eloquent-activities": "^1.0",
         "whilesmart/eloquent-agents": "dev-main",
         "whilesmart/eloquent-engagement": "dev-dev",
-        "whilesmart/eloquent-holdings": "^1.0",
+        "whilesmart/eloquent-holdings": "^1.1",
         "whilesmart/eloquent-model-configuration": "^1.0.9",
         "whilesmart/eloquent-outreach": "dev-dev",
         "whilesmart/eloquent-roles": "dev-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0635fd09d1774c0cfb7dadfafc82e49e",
+    "content-hash": "2979e99e43e1df97eb572c40ec5cd166",
     "packages": [
         {
             "name": "beste/clock",
@@ -8923,16 +8923,16 @@
         },
         {
             "name": "whilesmart/eloquent-holdings",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/whilesmartphp/eloquent-holdings.git",
-                "reference": "f58e8543f0ea10fa24458aed26f736426b16fc52"
+                "reference": "9aa77fe5deb6da0d08d7c2234ffa1b03a888afd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whilesmartphp/eloquent-holdings/zipball/f58e8543f0ea10fa24458aed26f736426b16fc52",
-                "reference": "f58e8543f0ea10fa24458aed26f736426b16fc52",
+                "url": "https://api.github.com/repos/whilesmartphp/eloquent-holdings/zipball/9aa77fe5deb6da0d08d7c2234ffa1b03a888afd2",
+                "reference": "9aa77fe5deb6da0d08d7c2234ffa1b03a888afd2",
                 "shasum": ""
             },
             "require": {
@@ -8971,9 +8971,9 @@
             "description": "Polymorphic holdings register (crypto, stocks, property, any asset) for Laravel: track quantity and value, with pluggable live pricing.",
             "support": {
                 "issues": "https://github.com/whilesmartphp/eloquent-holdings/issues",
-                "source": "https://github.com/whilesmartphp/eloquent-holdings/tree/v1.0.0"
+                "source": "https://github.com/whilesmartphp/eloquent-holdings/tree/v1.1.0"
             },
-            "time": "2026-06-27T11:16:36+00:00"
+            "time": "2026-07-04T21:10:17+00:00"
         },
         {
             "name": "whilesmart/eloquent-model-configuration",

--- a/config/holdings.php
+++ b/config/holdings.php
@@ -8,4 +8,7 @@ return [
 
     // Default fiat currency for new holdings when none is supplied.
     'default_currency' => env('HOLDINGS_DEFAULT_CURRENCY', 'USD'),
+
+    // Shape holdings responses like the rest of the Trakli API.
+    'response_formatter' => \App\Holdings\TrakliHoldingResponseFormatter::class,
 ];

--- a/tests/Feature/StatsControllerTest.php
+++ b/tests/Feature/StatsControllerTest.php
@@ -346,7 +346,8 @@ class StatsControllerTest extends TestCase
         ])->getJson('/api/v1/stats?wallet_ids=999999');
 
         $response->assertStatus(422)
-            ->assertJsonStructure(['message', 'invalid_wallet_ids']);
+            ->assertJsonPath('success', false)
+            ->assertJsonStructure(['message', 'errors' => ['invalid_wallet_ids']]);
     }
 
     /** @test */
@@ -906,7 +907,8 @@ class StatsControllerTest extends TestCase
 
         $response = $this->statsRequest('?section=bogus');
         $response->assertStatus(422)
-            ->assertJsonStructure(['message', 'invalid_section', 'valid_sections']);
+            ->assertJsonPath('success', false)
+            ->assertJsonStructure(['message', 'errors' => ['invalid_section', 'valid_sections']]);
     }
 
     /** @test */


### PR DESCRIPTION
Holdings and stats endpoints returned a different response shape than the rest of the API: holdings lists used another pagination layout and some responses had no `message`, and `/stats` returned no envelope at all. A client that expects one shape across the API can break on those.

Both now return the standard `{ success, message, data }`, error responses included. Holdings reaches it through the pluggable formatter added in `eloquent-holdings` 1.1.0, bound here to Trakli's shape; stats goes through the shared `success()`/`failure()`. The rule is written down in `AGENTS.md` so new endpoints keep to it.