### PR TITLE
feat(import): Read statement headers instead of fixed column positions

### DIFF
--- a/app/Contracts/ProvidesExtractionContext.php
+++ b/app/Contracts/ProvidesExtractionContext.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * A document processor that can surface the raw text/tables it extracted from
+ * the source document, so a downstream reviewer can validate parsed values
+ * (amount, date, currency) against the original document rather than trusting
+ * a positional guess.
+ */
+interface ProvidesExtractionContext
+{
+    /**
+     * The extracted document context from the most recent process() call, or
+     * null when the processor has no textual context (e.g. structured CSV/XML).
+     */
+    public function lastExtractionContext(): ?string;
+}

--- a/app/Enums/TransactionIntent.php
+++ b/app/Enums/TransactionIntent.php
@@ -12,6 +12,7 @@ enum TransactionIntent: string
     case INVESTMENT_BUY = 'investment_buy';
     case INVESTMENT_RETURN = 'investment_return';
     case GIFT = 'gift';
+    case FEE = 'fee';
 
     /**
      * @return string[]
@@ -29,6 +30,7 @@ enum TransactionIntent: string
             self::DEBT_OWED, self::DEBT_SETTLED => 'debt',
             self::INVESTMENT_BUY, self::INVESTMENT_RETURN => 'investment',
             self::GIFT => 'gift',
+            self::FEE => 'fee',
         };
     }
 
@@ -39,7 +41,7 @@ enum TransactionIntent: string
     public function sign(): int
     {
         return match ($this) {
-            self::LOAN_REPAYMENT, self::DEBT_SETTLED, self::INVESTMENT_BUY => -1,
+            self::LOAN_REPAYMENT, self::DEBT_SETTLED, self::INVESTMENT_BUY, self::FEE => -1,
             default => 1,
         };
     }

--- a/app/Http/Controllers/API/v1/ImportController.php
+++ b/app/Http/Controllers/API/v1/ImportController.php
@@ -499,11 +499,12 @@ class ImportController extends ApiController
             'parties' => $request->boolean('auto_create_parties', false),
             'categories' => $request->boolean('auto_create_categories', false),
         ];
+        $linkFees = $request->boolean('link_fees', false);
         $createdCount = 0;
         $errors = [];
 
         foreach ($accepted as $item) {
-            $result = $this->processAcceptedItem($item, $suggestions, $user, $autoCreate);
+            $result = $this->processAcceptedItem($item, $suggestions, $user, $autoCreate, $linkFees);
 
             if ($result === true) {
                 $createdCount++;
@@ -535,7 +536,7 @@ class ImportController extends ApiController
      *
      * @return true|string True on success, error message string on failure
      */
-    private function processAcceptedItem(array $item, array $suggestions, $user, array $autoCreate = []): true|string
+    private function processAcceptedItem(array $item, array $suggestions, $user, array $autoCreate = [], bool $linkFees = false): true|string
     {
         $index = $item['index'];
 
@@ -558,6 +559,7 @@ class ImportController extends ApiController
                 autoCreateWallets: $autoCreate['wallets'] ?? false,
                 autoCreateParties: $autoCreate['parties'] ?? false,
                 autoCreateCategories: $autoCreate['categories'] ?? false,
+                linkFee: $linkFees,
             );
 
             return true;
@@ -577,7 +579,7 @@ class ImportController extends ApiController
     private function mergeUserEdits(array $suggestion, array $item): array
     {
         $fields = [
-            'amount', 'type', 'description', 'date',
+            'amount', 'type', 'description', 'date', 'fee',
             'wallet_id', 'party_id', 'category_id',
         ];
         foreach ($fields as $field) {

--- a/app/Http/Requests/ImportConfirmRequest.php
+++ b/app/Http/Requests/ImportConfirmRequest.php
@@ -19,9 +19,11 @@ class ImportConfirmRequest extends FormRequest
             'accepted.*.type' => 'nullable|string|in:income,expense',
             'accepted.*.description' => 'nullable|string',
             'accepted.*.date' => 'nullable|date_format:Y-m-d',
+            'accepted.*.fee' => 'nullable|numeric|min:0',
             'auto_create_wallets' => 'nullable|boolean',
             'auto_create_parties' => 'nullable|boolean',
             'auto_create_categories' => 'nullable|boolean',
+            'link_fees' => 'nullable|boolean',
         ];
     }
 }

--- a/app/Jobs/AnalyzeImportJob.php
+++ b/app/Jobs/AnalyzeImportJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Contracts\ProvidesExtractionContext;
 use App\Models\ImportSession;
 use App\Services\DocumentProcessorManager;
 use App\Services\DuplicateDetectionService;
@@ -72,6 +73,10 @@ class AnalyzeImportJob implements ShouldQueue
             $processor = $processorManager->getProcessor($this->mimeType, $this->extension);
             $suggestions = $processor->process($file, $user);
 
+            $documentContext = $processor instanceof ProvidesExtractionContext
+                ? $processor->lastExtractionContext()
+                : null;
+
             if (empty($suggestions)) {
                 $session->update([
                     'status' => 'failed',
@@ -85,7 +90,7 @@ class AnalyzeImportJob implements ShouldQueue
             // Stage 2: Enriching
             $session->update(['status' => 'enriching']);
 
-            $suggestions = $enricher->enrich($suggestions, $user);
+            $suggestions = $enricher->enrich($suggestions, $user, $documentContext);
 
             // Stage 3: Checking duplicates
             $session->update(['status' => 'checking']);

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -117,6 +117,7 @@ class Transaction extends Model
         'wallet_id',
         'user_id',
         'transfer_id',
+        'metadata',
         'updated_at',
         'created_at',
     ];
@@ -129,6 +130,7 @@ class Transaction extends Model
     protected $casts = [
         'datetime' => 'datetime',
         'amount' => 'decimal:2',
+        'metadata' => 'array',
     ];
 
     protected $attributes = [

--- a/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
+++ b/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
@@ -5,6 +5,7 @@ namespace App\Services\DocumentProcessors;
 use App\Contracts\DocumentProcessor;
 use App\Contracts\ProvidesExtractionContext;
 use App\Models\User;
+use App\Services\StatementStructurer;
 use App\Types\TransactionSuggestion;
 use Carbon\Carbon;
 use Illuminate\Http\UploadedFile;
@@ -85,6 +86,17 @@ class RemoteDocumentProcessor implements DocumentProcessor, ProvidesExtractionCo
         // parsed values (amount, date, currency) against the source document.
         $rawText = $this->extractRawText($response);
         $this->lastContext = $rawText !== '' ? $rawText : null;
+
+        // OCR/text services collapse each row's columns into one string, so the
+        // fixed line-index mapping mis-slots values (an account number or phone
+        // code becomes the amount). Read the header semantically instead.
+        $mode = config('services.document_processor.response_mapping.mode', 'fields');
+        if ($mode === 'text_block' && $rawText !== '') {
+            $structured = (new StatementStructurer())->structure($rawText);
+            if (! empty($structured)) {
+                return $structured;
+            }
+        }
 
         $suggestions = $this->parseResponse($response);
 

--- a/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
+++ b/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
@@ -3,6 +3,7 @@
 namespace App\Services\DocumentProcessors;
 
 use App\Contracts\DocumentProcessor;
+use App\Contracts\ProvidesExtractionContext;
 use App\Models\User;
 use App\Types\TransactionSuggestion;
 use Carbon\Carbon;
@@ -35,9 +36,11 @@ use Prism\Prism\Facades\Prism;
  *       line_mapping: { date: 0, description: 1, amount: 2, currency: 3 } (line index per field)
  *       filter: { key: "subtype", value: "paragraph" } (optional, only process items matching this)
  */
-class RemoteDocumentProcessor implements DocumentProcessor
+class RemoteDocumentProcessor implements DocumentProcessor, ProvidesExtractionContext
 {
     private const SUPPORTED_EXTENSIONS = ['pdf', 'png', 'jpg', 'jpeg', 'tiff', 'tif', 'bmp'];
+
+    private ?string $lastContext = null;
 
     private const SUPPORTED_MIMES = [
         'application/pdf',
@@ -64,6 +67,8 @@ class RemoteDocumentProcessor implements DocumentProcessor
      */
     public function process(UploadedFile $file, User $user): array
     {
+        $this->lastContext = null;
+
         $url = config('services.document_processor.url');
 
         if (empty($url)) {
@@ -76,18 +81,25 @@ class RemoteDocumentProcessor implements DocumentProcessor
             return [];
         }
 
+        // Retain the extracted text/tables so the downstream review can validate
+        // parsed values (amount, date, currency) against the source document.
+        $rawText = $this->extractRawText($response);
+        $this->lastContext = $rawText !== '' ? $rawText : null;
+
         $suggestions = $this->parseResponse($response);
 
         // Fallback: if mapping couldn't extract transactions, send raw data to LLM
-        if (empty($suggestions)) {
-            $rawText = $this->extractRawText($response);
-            if (! empty($rawText)) {
-                Log::info('RemoteDocumentProcessor: mapping returned empty, falling back to LLM');
-                $suggestions = $this->extractViaLlm($rawText);
-            }
+        if (empty($suggestions) && ! empty($rawText)) {
+            Log::info('RemoteDocumentProcessor: mapping returned empty, falling back to LLM');
+            $suggestions = $this->extractViaLlm($rawText);
         }
 
         return $suggestions;
+    }
+
+    public function lastExtractionContext(): ?string
+    {
+        return $this->lastContext;
     }
 
     private function callRemote(UploadedFile $file): ?array
@@ -197,6 +209,10 @@ class RemoteDocumentProcessor implements DocumentProcessor
                 continue;
             }
 
+            if ($this->isLikelyNonMonetary((string) $amount)) {
+                continue;
+            }
+
             $rawAmount = (float) str_replace(',', '', (string) $amount);
             $type = Arr::get($tx, $typeField);
 
@@ -265,6 +281,10 @@ class RemoteDocumentProcessor implements DocumentProcessor
             return null;
         }
 
+        if ($this->isLikelyNonMonetary($amount)) {
+            return null;
+        }
+
         $normalizedDate = $this->normalizeDate($date);
         if ($normalizedDate === null) {
             return null;
@@ -309,6 +329,20 @@ class RemoteDocumentProcessor implements DocumentProcessor
         }
 
         return null;
+    }
+
+    /**
+     * Conservative, non-AI floor: reject tokens that are clearly identifiers
+     * rather than money. A monetary amount never has a leading zero on its
+     * integer part, so a long leading-zero digit run (e.g. "0244123456") is an
+     * account/phone/reference number, not an amount. Deliberately narrow so it
+     * never drops a valid amount; the nuanced correction is the reviewer's job.
+     */
+    private function isLikelyNonMonetary(string $raw): bool
+    {
+        $digits = preg_replace('/[\s,]/', '', trim($raw));
+
+        return (bool) preg_match('/^0\d{6,}$/', (string) $digits);
     }
 
     private function getLine(array $lines, ?int $index): ?string

--- a/app/Services/FileImportService.php
+++ b/app/Services/FileImportService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\TransactionIntent;
 use App\Enums\TransactionType;
 use App\Events\ImportComplete;
 use App\Events\ImportFailed;
@@ -278,8 +279,9 @@ class FileImportService
         bool $autoCreateWallets = false,
         bool $autoCreateParties = false,
         bool $autoCreateCategories = false,
+        bool $linkFee = false,
     ): void {
-        DB::transaction(function () use ($merged, $transactionType, $user, $autoCreateWallets, $autoCreateParties, $autoCreateCategories) {
+        DB::transaction(function () use ($merged, $transactionType, $user, $autoCreateWallets, $autoCreateParties, $autoCreateCategories, $linkFee) {
             $wallet = $this->resolveWalletForConfirm(
                 $user,
                 $merged['wallet_id'] ?? null,
@@ -313,7 +315,57 @@ class FileImportService
             if (! is_null($category)) {
                 $transaction->categories()->sync([$category->id]);
             }
+
+            $fee = (float) ($merged['fee'] ?? 0);
+            if ($fee > 0) {
+                $this->createFeeTransaction(
+                    $user,
+                    $wallet,
+                    $fee,
+                    $merged['date'] ?? null,
+                    $linkFee ? $transaction->id : null,
+                );
+            }
         });
+    }
+
+    /**
+     * A statement fee is real spending that went to the provider, so it becomes
+     * its own expense attributed to a "Charges" party and tagged with the fee
+     * intent. It is linked back to the transaction it came from only on request.
+     */
+    private function createFeeTransaction(
+        User $user,
+        \App\Models\Wallet $wallet,
+        float $fee,
+        ?string $date,
+        ?int $linkedTransactionId,
+    ): void {
+        $charges = $this->resolveChargesParty($user);
+
+        $user->transactions()->create([
+            'amount' => $fee,
+            'description' => __('Transaction fee'),
+            'datetime' => $date,
+            'type' => TransactionType::EXPENSE->value,
+            'intent' => TransactionIntent::FEE->value,
+            'wallet_id' => $wallet->id,
+            'party_id' => $charges->id,
+            'metadata' => $linkedTransactionId ? ['fee_of_transaction_id' => $linkedTransactionId] : null,
+        ]);
+    }
+
+    private function resolveChargesParty(User $user): \App\Models\Party
+    {
+        $existing = $user->parties()->where('name', 'Charges')->first();
+        if (! is_null($existing)) {
+            return $existing;
+        }
+
+        return $user->parties()->create([
+            'name' => 'Charges',
+            'type' => 'service',
+        ]);
     }
 
     /**

--- a/app/Services/StatementStructurer.php
+++ b/app/Services/StatementStructurer.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Services;
+
+use App\Types\TransactionSuggestion;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Prism\Prism\Facades\Prism;
+
+/**
+ * Header-aware structured extraction from a statement's raw text.
+ *
+ * Statement extractors (OCR/table services) collapse each row into one
+ * delimiter-less string, so the column each value belongs to can only be
+ * recovered by reading the header semantically. This sends the raw text
+ * (header included) to an LLM and gets back one structured object per
+ * transaction, disambiguating the amount from phone numbers, transaction ids,
+ * fees and balances that share the row.
+ *
+ * When the LLM is unavailable or its response cannot be parsed, this returns an
+ * empty array so the caller can fall back to its previous extraction path. It
+ * never throws.
+ */
+class StatementStructurer
+{
+    private const MAX_INPUT_CHARS = 12000;
+
+    /**
+     * @return TransactionSuggestion[]
+     */
+    public function structure(string $rawText, ?string $documentType = null): array
+    {
+        $rawText = trim($rawText);
+        if ($rawText === '') {
+            return [];
+        }
+
+        try {
+            $response = Prism::text()
+                ->using(
+                    config('services.llm.provider', 'groq'),
+                    config('services.llm.model', 'llama-3.1-8b-instant'),
+                )
+                ->withSystemPrompt($this->systemPrompt())
+                ->withPrompt($this->buildPrompt($rawText, $documentType))
+                ->usingTemperature(0)
+                ->asText();
+
+            $rows = $this->parseJson($response->text);
+
+            if (! is_array($rows)) {
+                return [];
+            }
+
+            return $this->toSuggestions($rows);
+        } catch (\Throwable $e) {
+            Log::warning('StatementStructurer: LLM unavailable, skipping structured extraction', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    private function systemPrompt(): string
+    {
+        return <<<'PROMPT'
+You extract transactions from the raw text of a financial statement.
+
+The text is extracted from a table, so each transaction's values may run
+together on one line with no separators. A header line names the columns; use it
+to decide which value is which. Statements commonly have these columns: date &
+time, payment type, to/from, account, name, amount, transaction id, fees, tax,
+balance, reference.
+
+DISAMBIGUATION (critical):
+- amount is the transaction's monetary value. It is NOT the phone number
+  (e.g. "+237 68 09 11 37 4"), NOT the transaction id (a long 10+ digit number),
+  NOT the fee, tax or balance. When a row has several numbers, the amount is the
+  one in the amount column, usually signed (e.g. "-2000" or "+150000").
+- direction: "expense" when money leaves the account (debit, negative amount,
+  payment/transfer/withdrawal/airtime), "income" when money arrives (credit,
+  positive amount, deposit/received).
+- counterparty_name is the person or business name, NOT the payment type.
+- account is the phone number or account identifier of the counterparty.
+
+For EACH transaction return an object with these keys:
+- date: "YYYY-MM-DD"
+- description: a short human-readable summary (payment type and counterparty)
+- payment_type: the raw payment type (e.g. "MOMO USER", "AIRTIME", "CASH OUT")
+- counterparty_name: the other party's name, or null
+- account: the counterparty phone/account, or null
+- amount: a positive number (the transaction value)
+- direction: "income" or "expense"
+- fee: a number, or null if none
+- tax: a number, or null if none
+- balance: a number, or null
+- reference: the reference/transaction id text, or null
+- currency: 3-letter code (e.g. "XAF"), or null
+
+Respond with ONLY a JSON array. No prose, no markdown fences. Skip header,
+subtotal and footer lines that are not transactions.
+PROMPT;
+    }
+
+    private function buildPrompt(string $rawText, ?string $documentType): string
+    {
+        $parts = [];
+
+        if (! empty($documentType)) {
+            $parts[] = "Document type: {$documentType}";
+        }
+
+        $parts[] = "Statement text:\n\n" . mb_substr($rawText, 0, self::MAX_INPUT_CHARS);
+
+        return implode("\n\n", $parts);
+    }
+
+    private function parseJson(string $text): ?array
+    {
+        $text = trim($text);
+
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text);
+            $text = preg_replace('/\s*```$/', '', $text);
+        }
+
+        $decoded = json_decode($text, true);
+
+        return (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) ? $decoded : null;
+    }
+
+    /**
+     * @return TransactionSuggestion[]
+     */
+    private function toSuggestions(array $rows): array
+    {
+        $suggestions = [];
+
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $amount = $this->number($row['amount'] ?? null);
+            $date = $this->normalizeDate($row['date'] ?? null);
+
+            if ($amount === null || $amount == 0.0 || $date === null) {
+                continue;
+            }
+
+            $direction = strtolower((string) ($row['direction'] ?? ''));
+            $type = in_array($direction, ['income', 'expense'], true)
+                ? $direction
+                : ($amount < 0 ? 'expense' : 'income');
+
+            $suggestions[] = new TransactionSuggestion(
+                amount: abs($amount),
+                currency: $this->currency($row['currency'] ?? null),
+                type: $type,
+                party: $this->text($row['counterparty_name'] ?? null),
+                description: $this->text($row['description'] ?? null) ?? $this->text($row['payment_type'] ?? null),
+                date: $date,
+                confidence: 0.8,
+                documentType: 'statement',
+                fee: $this->number($row['fee'] ?? null),
+                tax: $this->number($row['tax'] ?? null),
+                account: $this->text($row['account'] ?? null),
+                reference: $this->text($row['reference'] ?? null),
+            );
+        }
+
+        return $suggestions;
+    }
+
+    private function number(mixed $value): ?float
+    {
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        if (is_string($value)) {
+            $cleaned = str_replace(',', '', trim($value));
+            if (is_numeric($cleaned)) {
+                return (float) $cleaned;
+            }
+        }
+
+        return null;
+    }
+
+    private function text(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function currency(mixed $value): ?string
+    {
+        if (is_string($value) && preg_match('/^[A-Za-z]{3}$/', trim($value))) {
+            return strtoupper(trim($value));
+        }
+
+        return null;
+    }
+
+    private function normalizeDate(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            return $value;
+        }
+
+        try {
+            return Carbon::parse(str_replace(',', '', $value))->format('Y-m-d');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/app/Services/StatsService.php
+++ b/app/Services/StatsService.php
@@ -180,7 +180,9 @@ class StatsService
             $amount = $this->convertCurrency((float) $row->total_amount, $row->currency);
             $intent = TransactionIntent::tryFrom($row->intent ?? 'regular') ?? TransactionIntent::REGULAR;
 
-            if ($intent === TransactionIntent::REGULAR) {
+            // A fee is real spending that erodes net worth; treat it like a
+            // regular expense here even though it is tagged separately.
+            if ($intent === TransactionIntent::REGULAR || $intent === TransactionIntent::FEE) {
                 if ($row->type === 'income') {
                     $earnedIncome += $amount;
                 } else {

--- a/app/Services/SuggestionEnricher.php
+++ b/app/Services/SuggestionEnricher.php
@@ -10,13 +10,20 @@ use Prism\Prism\Facades\Prism;
 class SuggestionEnricher
 {
     /**
-     * Enrich raw transaction suggestions by mapping them to the user's
-     * existing wallets, categories, and parties using an LLM.
+     * Enrich raw transaction suggestions by mapping them to the user's existing
+     * wallets, categories, and parties. When the source document context is
+     * supplied, it also validates the parsed amount, currency, and date against
+     * that document so a mis-extracted value (e.g. an account number picked up
+     * as an amount) gets corrected. Uses an LLM; when it is unavailable the raw
+     * suggestions are returned unchanged.
      *
      * @param  TransactionSuggestion[]  $suggestions
+     * @param  string|null  $documentContext  Raw extracted text/tables from the
+     *                                        source document, used as ground
+     *                                        truth for value correction.
      * @return TransactionSuggestion[]
      */
-    public function enrich(array $suggestions, User $user): array
+    public function enrich(array $suggestions, User $user, ?string $documentContext = null): array
     {
         if (empty($suggestions)) {
             return [];
@@ -26,8 +33,8 @@ class SuggestionEnricher
         $categories = $user->categories()->select('name', 'type')->get()->toArray();
         $parties = $user->parties()->select('name')->get()->toArray();
 
-        // If user has no existing entities, skip LLM call — nothing to match against
-        // but still try to classify type and clean descriptions
+        // With no existing entities there is nothing to match against; the LLM
+        // still classifies type and cleans descriptions.
         $suggestionsData = array_map(fn (TransactionSuggestion $suggestion) => [
             'amount' => $suggestion->amount,
             'currency' => $suggestion->currency,
@@ -39,7 +46,7 @@ class SuggestionEnricher
             'date' => $suggestion->date,
         ], $suggestions);
 
-        $prompt = $this->buildPrompt($suggestionsData, $wallets, $categories, $parties);
+        $prompt = $this->buildPrompt($suggestionsData, $wallets, $categories, $parties, $documentContext);
 
         try {
             $response = Prism::text()
@@ -72,7 +79,7 @@ class SuggestionEnricher
     private function systemPrompt(): string
     {
         return <<<'PROMPT'
-You are a financial transaction classifier.
+You are a financial transaction classifier and validator.
 
 CRITICAL RULES:
 - wallet: MUST match by currency. A EUR transaction can ONLY go to a EUR wallet.
@@ -83,16 +90,41 @@ CRITICAL RULES:
 - type: "income" for money received, "expense" for money spent.
 - description: Clean up raw text (e.g. "AMZN MKTP US*ABC123" → "Amazon Marketplace").
 
+VALUE VALIDATION (amount, currency, date):
+- A SOURCE DOCUMENT section may be provided below. When it is, use it as ground
+  truth to correct values that were mis-extracted.
+- amount: a positive number, the transaction's monetary value. If the provided
+  amount is actually an account number, phone number, reference or balance (NOT
+  the transaction value), replace it with the correct amount from the SOURCE
+  DOCUMENT. Never return a negative amount; direction is carried by "type".
+- currency: a 3-letter code; correct it only if the SOURCE DOCUMENT clearly shows
+  a different currency.
+- date: YYYY-MM-DD; correct it only if the SOURCE DOCUMENT clearly shows a
+  different date.
+- If NO SOURCE DOCUMENT section is present, echo amount, currency and date back
+  EXACTLY as given; do not guess.
+
 OUTPUT FORMAT:
 - Respond with ONLY a valid JSON array. No other text, no markdown code fences.
-- Each element must have exactly these keys: wallet, category, party, type, description.
-- Use null (not empty string) when no match is found.
+- Each element must have exactly these keys: wallet, category, party, type,
+  description, amount, currency, date.
+- Use null (not empty string) when no match is found for wallet, category or party.
 PROMPT;
     }
 
-    private function buildPrompt(array $suggestions, array $wallets, array $categories, array $parties): string
-    {
+    private function buildPrompt(
+        array $suggestions,
+        array $wallets,
+        array $categories,
+        array $parties,
+        ?string $documentContext = null,
+    ): string {
         $parts = [];
+
+        if (! empty($documentContext)) {
+            $parts[] = '=== SOURCE DOCUMENT (ground truth for amount, currency, date) ===';
+            $parts[] = mb_substr($documentContext, 0, 8000);
+        }
 
         $parts[] = '=== AVAILABLE WALLETS (use ONLY these, matched by currency) ===';
         if (! empty($wallets)) {
@@ -100,7 +132,7 @@ PROMPT;
                 $parts[] = "- \"{$wallet['name']}\" (currency: {$wallet['currency']})";
             }
         } else {
-            $parts[] = 'None — set wallet to null for all transactions.';
+            $parts[] = 'None available; set wallet to null for all transactions.';
         }
 
         $parts[] = "\n=== AVAILABLE CATEGORIES ===";
@@ -109,7 +141,7 @@ PROMPT;
                 $parts[] = "- \"{$category['name']}\" (type: {$category['type']})";
             }
         } else {
-            $parts[] = 'None — set category to null.';
+            $parts[] = 'None available; set category to null.';
         }
 
         $parts[] = "\n=== AVAILABLE PARTIES ===";
@@ -118,7 +150,7 @@ PROMPT;
                 $parts[] = "- \"{$party['name']}\"";
             }
         } else {
-            $parts[] = 'None — set party to null.';
+            $parts[] = 'None available; set party to null.';
         }
 
         $count = count($suggestions);
@@ -173,7 +205,12 @@ PROMPT;
             $enrichment = $enrichments[$i] ?? [];
             $assignedWallet = $enrichment['wallet'] ?? $suggestion->wallet;
 
-            $currency = $suggestion->currency;
+            // Value corrections are grounded in the source document; fall back to
+            // the originally parsed value whenever the correction is unusable.
+            $amount = $this->correctedAmount($enrichment['amount'] ?? null, $suggestion->amount);
+            $date = $this->correctedDate($enrichment['date'] ?? null, $suggestion->date);
+
+            $currency = $this->correctedCurrency($enrichment['currency'] ?? null, $suggestion->currency);
             if ($assignedWallet) {
                 $slug = $slugByName[$assignedWallet] ?? null;
                 if ($slug && isset($walletsBySlug[$slug])) {
@@ -182,19 +219,53 @@ PROMPT;
             }
 
             $result[] = new TransactionSuggestion(
-                amount: $suggestion->amount,
+                amount: $amount,
                 currency: $currency,
                 type: $enrichment['type'] ?? $suggestion->type,
                 party: $enrichment['party'] ?? $suggestion->party,
                 wallet: $assignedWallet,
                 category: $enrichment['category'] ?? $suggestion->category,
                 description: $enrichment['description'] ?? $suggestion->description,
-                date: $suggestion->date,
+                date: $date,
                 confidence: $suggestion->confidence,
                 documentType: $suggestion->documentType,
             );
         }
 
         return $result;
+    }
+
+    /**
+     * Accept a corrected amount only when it is a usable positive number;
+     * otherwise keep the originally parsed value.
+     */
+    private function correctedAmount(mixed $corrected, ?float $original): ?float
+    {
+        if (is_numeric($corrected)) {
+            $value = abs((float) $corrected);
+            if ($value > 0) {
+                return $value;
+            }
+        }
+
+        return $original;
+    }
+
+    private function correctedDate(mixed $corrected, ?string $original): ?string
+    {
+        if (is_string($corrected) && preg_match('/^\d{4}-\d{2}-\d{2}$/', trim($corrected))) {
+            return trim($corrected);
+        }
+
+        return $original;
+    }
+
+    private function correctedCurrency(mixed $corrected, ?string $original): ?string
+    {
+        if (is_string($corrected) && preg_match('/^[A-Za-z]{3}$/', trim($corrected))) {
+            return strtoupper(trim($corrected));
+        }
+
+        return $original;
     }
 }

--- a/app/Types/TransactionSuggestion.php
+++ b/app/Types/TransactionSuggestion.php
@@ -16,6 +16,10 @@ readonly class TransactionSuggestion
         public ?string $date = null,
         public float $confidence = 1.0,
         public ?string $documentType = null,
+        public ?float $fee = null,
+        public ?float $tax = null,
+        public ?string $account = null,
+        public ?string $reference = null,
     ) {
     }
 
@@ -32,6 +36,10 @@ readonly class TransactionSuggestion
             'date' => $this->date,
             'confidence' => $this->confidence,
             'document_type' => $this->documentType,
+            'fee' => $this->fee,
+            'tax' => $this->tax,
+            'account' => $this->account,
+            'reference' => $this->reference,
         ];
     }
 
@@ -65,6 +73,10 @@ readonly class TransactionSuggestion
             date: $data['date'] ?? null,
             confidence: (float) ($data['confidence'] ?? 1.0),
             documentType: $data['document_type'] ?? null,
+            fee: isset($data['fee']) ? (float) $data['fee'] : null,
+            tax: isset($data['tax']) ? (float) $data['tax'] : null,
+            account: $data['account'] ?? null,
+            reference: $data['reference'] ?? null,
         );
     }
 }

--- a/database/migrations/2026_07_06_000001_add_metadata_to_transactions_table.php
+++ b/database/migrations/2026_07_06_000001_add_metadata_to_transactions_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->json('metadata')->nullable()->after('intent');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropColumn('metadata');
+        });
+    }
+};

--- a/tests/Feature/AdvancedImportTest.php
+++ b/tests/Feature/AdvancedImportTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Enums\TransactionIntent;
+use App\Enums\TransactionType;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -302,6 +304,61 @@ class AdvancedImportTest extends TestCase
         $this->assertEquals('confirmed', $session->status);
 
         $this->assertEquals(2, $this->user->transactions()->count());
+    }
+
+    public function test_confirm_creates_a_charges_expense_for_a_fee(): void
+    {
+        $wallet = $this->user->wallets()->create(['name' => 'MoMo', 'currency' => 'XAF']);
+
+        $session = $this->makeReadySession([
+            $this->sampleSuggestion(['amount' => 2000.00, 'type' => 'expense', 'currency' => 'XAF', 'fee' => 8.00]),
+        ]);
+
+        $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [['index' => 0, 'wallet_id' => $wallet->id]],
+        ])->assertStatus(200);
+
+        // The transaction plus a separate fee expense.
+        $this->assertEquals(2, $this->user->transactions()->count());
+
+        $fee = $this->user->transactions()->where('intent', TransactionIntent::FEE->value)->first();
+        $this->assertNotNull($fee);
+        $this->assertEquals(8.00, (float) $fee->amount);
+        $this->assertEquals(TransactionType::EXPENSE->value, $fee->type);
+        $this->assertEquals($wallet->id, $fee->wallet_id);
+
+        $charges = $this->user->parties()->where('name', 'Charges')->first();
+        $this->assertNotNull($charges);
+        $this->assertEquals($charges->id, $fee->party_id);
+
+        // Unlinked by default.
+        $this->assertNull($fee->metadata);
+    }
+
+    public function test_confirm_links_the_fee_to_its_transaction_on_request(): void
+    {
+        $wallet = $this->user->wallets()->create(['name' => 'MoMo', 'currency' => 'XAF']);
+
+        $session = $this->makeReadySession([
+            $this->sampleSuggestion(['amount' => 2000.00, 'type' => 'expense', 'currency' => 'XAF', 'fee' => 8.00]),
+        ]);
+
+        $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [['index' => 0, 'wallet_id' => $wallet->id]],
+            'link_fees' => true,
+        ])->assertStatus(200);
+
+        $main = $this->user->transactions()
+            ->where('intent', '!=', TransactionIntent::FEE->value)
+            ->where('amount', 2000.00)
+            ->first();
+        $fee = $this->user->transactions()->where('intent', TransactionIntent::FEE->value)->first();
+
+        $this->assertNotNull($main);
+        $this->assertNotNull($fee);
+        $this->assertEquals($main->id, $fee->metadata['fee_of_transaction_id']);
     }
 
     public function test_confirm_accepts_party_id_and_category_id(): void

--- a/tests/Unit/Services/DocumentProcessors/RemoteDocumentProcessorTest.php
+++ b/tests/Unit/Services/DocumentProcessors/RemoteDocumentProcessorTest.php
@@ -327,6 +327,73 @@ class RemoteDocumentProcessorTest extends TestCase
         $this->assertEquals(100.00, $result[0]->amount);
     }
 
+    public function test_leading_zero_account_number_is_not_treated_as_amount(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'text_block',
+                'transactions_path' => 'elements',
+                'content_field' => 'content',
+                'line_mapping' => [
+                    'date' => 0,
+                    'description' => 1,
+                    'amount' => 2,
+                    'currency' => 3,
+                ],
+            ],
+        ]);
+
+        // First block's "amount" line is really an account/phone number
+        // (leading zero, long digit run); the second is a genuine amount.
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'elements' => [
+                    ['content' => "2025-03-15\nMoMo transfer\n0244123456\nGHS"],
+                    ['content' => "2025-03-16\nAirtime purchase\n25.00\nGHS"],
+                ],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('momo.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(25.00, $result[0]->amount);
+        $this->assertEquals('Airtime purchase', $result[0]->description);
+    }
+
+    public function test_last_extraction_context_is_populated_from_response(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'fields',
+                'transactions_path' => 'transactions',
+            ],
+        ]);
+
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'transactions' => [],
+                'elements' => [
+                    ['content' => 'MoMo transfer to 0244123456 amount GHS 25.00'],
+                ],
+            ], 200),
+        ]);
+
+        $file = UploadedFile::fake()->create('momo.pdf', 100, 'application/pdf');
+
+        $this->processor->process($file, $this->user);
+
+        $context = $this->processor->lastExtractionContext();
+        $this->assertNotNull($context);
+        $this->assertStringContainsString('GHS 25.00', $context);
+    }
+
     public function test_llm_fallback_when_mapping_returns_empty(): void
     {
         config([

--- a/tests/Unit/Services/DocumentProcessors/RemoteDocumentProcessorTest.php
+++ b/tests/Unit/Services/DocumentProcessors/RemoteDocumentProcessorTest.php
@@ -29,6 +29,26 @@ class RemoteDocumentProcessorTest extends TestCase
         $this->user = User::factory()->create();
     }
 
+    /**
+     * In text_block mode the header-aware structurer runs first; fake it to
+     * return nothing so these tests exercise the positional fallback path.
+     */
+    private function fakeStructurerReturnsNothing(): void
+    {
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: '[]',
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+    }
+
     public function test_supports_returns_false_when_no_url_configured(): void
     {
         config(['services.document_processor.url' => null]);
@@ -129,6 +149,8 @@ class RemoteDocumentProcessorTest extends TestCase
 
     public function test_parse_response_in_text_block_mode(): void
     {
+        $this->fakeStructurerReturnsNothing();
+
         config([
             'services.document_processor.url' => 'https://example.com/parse',
             'services.document_processor.auth_type' => 'none',
@@ -289,6 +311,8 @@ class RemoteDocumentProcessorTest extends TestCase
 
     public function test_skipped_status_transactions_excluded_in_text_block_mode(): void
     {
+        $this->fakeStructurerReturnsNothing();
+
         config([
             'services.document_processor.url' => 'https://example.com/parse',
             'services.document_processor.auth_type' => 'none',
@@ -329,6 +353,8 @@ class RemoteDocumentProcessorTest extends TestCase
 
     public function test_leading_zero_account_number_is_not_treated_as_amount(): void
     {
+        $this->fakeStructurerReturnsNothing();
+
         config([
             'services.document_processor.url' => 'https://example.com/parse',
             'services.document_processor.auth_type' => 'none',
@@ -392,6 +418,71 @@ class RemoteDocumentProcessorTest extends TestCase
         $context = $this->processor->lastExtractionContext();
         $this->assertNotNull($context);
         $this->assertStringContainsString('GHS 25.00', $context);
+    }
+
+    public function test_text_block_mode_uses_header_aware_structurer(): void
+    {
+        config([
+            'services.document_processor.url' => 'https://example.com/parse',
+            'services.document_processor.auth_type' => 'none',
+            'services.document_processor.response_mapping' => [
+                'mode' => 'text_block',
+                'transactions_path' => 'elements',
+                'content_field' => 'content',
+            ],
+        ]);
+
+        // A real mashed MoMo row: columns run together, phone code and ids share
+        // the line with the amount and fee.
+        Http::fake([
+            'https://example.com/parse' => Http::response([
+                'elements' => [
+                    ['content' => "Date & Time Payment Type To/From Account Name Amount Transaction ID Fees Tax Balance Reference\n15 Jun 2026 20:12 MOMO USER +237 68 09 11 37 4 NAOMI KAYLANI FON AKE -2000 17544382009 8.00 XAF 0.00 XAF 5,200 XAF Charges"],
+                ],
+            ], 200),
+        ]);
+
+        // The header-aware structurer resolves the columns.
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: json_encode([[
+                    'date' => '2026-06-15',
+                    'description' => 'MoMo transfer to NAOMI KAYLANI FON AKE',
+                    'payment_type' => 'MOMO USER',
+                    'counterparty_name' => 'NAOMI KAYLANI FON AKE',
+                    'account' => '+237 68 09 11 37 4',
+                    'amount' => 2000,
+                    'direction' => 'expense',
+                    'fee' => 8.00,
+                    'tax' => 0,
+                    'balance' => 5200,
+                    'reference' => 'Charges',
+                    'currency' => 'XAF',
+                ]]),
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $file = UploadedFile::fake()->create('momo.pdf', 100, 'application/pdf');
+
+        $result = $this->processor->process($file, $this->user);
+
+        $this->assertCount(1, $result);
+        $suggestion = $result[0];
+        $this->assertEquals(2000.0, $suggestion->amount);
+        $this->assertEquals('expense', $suggestion->type);
+        $this->assertEquals('NAOMI KAYLANI FON AKE', $suggestion->party);
+        $this->assertEquals('+237 68 09 11 37 4', $suggestion->account);
+        $this->assertEquals(8.00, $suggestion->fee);
+        $this->assertEquals('XAF', $suggestion->currency);
+        $this->assertEquals('2026-06-15', $suggestion->date);
+        $this->assertEquals('statement', $suggestion->documentType);
     }
 
     public function test_llm_fallback_when_mapping_returns_empty(): void

--- a/tests/Unit/Services/StatementStructurerTest.php
+++ b/tests/Unit/Services/StatementStructurerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\StatementStructurer;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
+use Tests\TestCase;
+
+class StatementStructurerTest extends TestCase
+{
+    private function fakePrism(string $text): void
+    {
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $text,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+    }
+
+    public function test_maps_structured_rows_and_disambiguates_amount(): void
+    {
+        $this->fakePrism(json_encode([[
+            'date' => '2026-06-15',
+            'description' => 'Airtime purchase',
+            'payment_type' => 'AIRTIME',
+            'counterparty_name' => 'MTNC AIRTIME',
+            'account' => '+237 68 11 04 87 5',
+            'amount' => 1000,
+            'direction' => 'expense',
+            'fee' => 0,
+            'tax' => 0,
+            'balance' => 2516,
+            'reference' => '17038916245',
+            'currency' => 'XAF',
+        ]]));
+
+        $rawText = "Date & Time Payment Type Account Name Amount Transaction ID Fees Tax Balance Reference\n"
+            . '9 May 2026 12:43 AIRTIME +237 68 11 04 87 5 MTNC AIRTIME -1000 17038916245 0.00 XAF 0.00 XAF 2,516 XAF -';
+
+        $result = (new StatementStructurer())->structure($rawText);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(1000.0, $result[0]->amount);
+        $this->assertEquals('expense', $result[0]->type);
+        $this->assertEquals('MTNC AIRTIME', $result[0]->party);
+        $this->assertEquals('+237 68 11 04 87 5', $result[0]->account);
+        $this->assertEquals('XAF', $result[0]->currency);
+        $this->assertEquals('2026-06-15', $result[0]->date);
+    }
+
+    public function test_returns_empty_when_llm_output_unparseable(): void
+    {
+        $this->fakePrism('this is not json');
+
+        $result = (new StatementStructurer())->structure('some statement text');
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_returns_empty_for_blank_input_without_calling_llm(): void
+    {
+        $result = (new StatementStructurer())->structure("   \n  ");
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Unit/Services/SuggestionEnricherTest.php
+++ b/tests/Unit/Services/SuggestionEnricherTest.php
@@ -291,6 +291,119 @@ class SuggestionEnricherTest extends TestCase
         $this->assertEquals('expense', $result[0]->type);
     }
 
+    public function test_document_context_corrects_account_number_mistaken_for_amount(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'MoMo',
+            'currency' => 'GHS',
+            'type' => 'mobile',
+        ]);
+
+        // The reviewer, given the source document, replaces the account-number
+        // amount with the real transaction value and echoes date/currency.
+        $llmResponse = json_encode([
+            [
+                'wallet' => 'MoMo',
+                'category' => null,
+                'party' => 'Airtime',
+                'type' => 'expense',
+                'description' => 'Airtime purchase',
+                'amount' => 25.00,
+                'currency' => 'GHS',
+                'date' => '2025-03-16',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        // Parsed amount is actually an account number picked from the statement.
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 244123456.0,
+                currency: 'GHS',
+                type: 'expense',
+                description: 'Airtime purchase',
+                date: '2025-03-16',
+                confidence: 0.8,
+            ),
+        ];
+
+        $context = "2025-03-16\nAirtime purchase to 0244123456\nAmount: GHS 25.00";
+
+        $result = $this->enricher->enrich($suggestions, $this->user, $context);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(25.00, $result[0]->amount);
+        $this->assertEquals('GHS', $result[0]->currency);
+        $this->assertEquals('2025-03-16', $result[0]->date);
+    }
+
+    public function test_invalid_corrected_amount_falls_back_to_original(): void
+    {
+        $this->user->wallets()->create([
+            'name' => 'MoMo',
+            'currency' => 'GHS',
+            'type' => 'mobile',
+        ]);
+
+        // LLM returns a non-numeric amount and a malformed date; both must be
+        // ignored in favour of the originally parsed values.
+        $llmResponse = json_encode([
+            [
+                'wallet' => 'MoMo',
+                'category' => null,
+                'party' => null,
+                'type' => 'expense',
+                'description' => 'Groceries',
+                'amount' => 'not-a-number',
+                'currency' => 'GH',
+                'date' => 'March 16',
+            ],
+        ]);
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: $llmResponse,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(0, 0),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $suggestions = [
+            new TransactionSuggestion(
+                amount: 42.50,
+                currency: 'GHS',
+                type: 'expense',
+                description: 'Groceries',
+                date: '2025-03-16',
+                confidence: 0.8,
+            ),
+        ];
+
+        $result = $this->enricher->enrich($suggestions, $this->user, 'some document text');
+
+        $this->assertCount(1, $result);
+        $this->assertEquals(42.50, $result[0]->amount);
+        $this->assertEquals('GHS', $result[0]->currency);
+        $this->assertEquals('2025-03-16', $result[0]->date);
+    }
+
     public function test_enrichment_strips_markdown_fences_from_llm_response(): void
     {
         $this->user->wallets()->create([
@@ -299,7 +412,7 @@ class SuggestionEnricherTest extends TestCase
             'type' => 'cash',
         ]);
 
-        $llmResponse = "```json\n" . json_encode([
+        $llmResponse = "```json\n".json_encode([
             [
                 'wallet' => 'Wallet',
                 'category' => 'Travel',
@@ -307,7 +420,7 @@ class SuggestionEnricherTest extends TestCase
                 'type' => 'expense',
                 'description' => 'Flight ticket',
             ],
-        ]) . "\n```";
+        ])."\n```";
 
         Prism::fake([
             new TextResponse(

--- a/tests/Unit/Types/TransactionSuggestionTest.php
+++ b/tests/Unit/Types/TransactionSuggestionTest.php
@@ -35,6 +35,10 @@ class TransactionSuggestionTest extends TestCase
             'date' => '2025-01-15',
             'confidence' => 0.95,
             'document_type' => 'csv',
+            'fee' => null,
+            'tax' => null,
+            'account' => null,
+            'reference' => null,
         ], $array);
     }
 
@@ -128,6 +132,29 @@ class TransactionSuggestionTest extends TestCase
         $this->assertNull($suggestion->date);
         $this->assertEquals(1.0, $suggestion->confidence);
         $this->assertNull($suggestion->documentType);
+        $this->assertNull($suggestion->fee);
+        $this->assertNull($suggestion->tax);
+        $this->assertNull($suggestion->account);
+        $this->assertNull($suggestion->reference);
+    }
+
+    public function test_fee_account_and_reference_round_trip(): void
+    {
+        $original = new TransactionSuggestion(
+            amount: 2000.0,
+            type: 'expense',
+            fee: 8.0,
+            tax: 0.0,
+            account: '+237 68 09 11 37 4',
+            reference: '17544382009',
+        );
+
+        $restored = TransactionSuggestion::fromArray($original->toArray());
+
+        $this->assertEquals(8.0, $restored->fee);
+        $this->assertEquals(0.0, $restored->tax);
+        $this->assertEquals('+237 68 09 11 37 4', $restored->account);
+        $this->assertEquals('17544382009', $restored->reference);
     }
 
     public function test_from_array_handles_missing_keys_gracefully(): void


### PR DESCRIPTION
Statement imports were mis-reading columns; several related problems, fixed together.

Real MTN MoMo statements come back from the extractor with every row's columns collapsed into one delimiter-less string. The old importer mapped values by fixed line position, so it mis-slotted everything: the payment type became the description, a phone code or transaction id became the amount, the direction was wrong, and the counterparty name and fees were dropped. For text-based documents it now reads the header line and lets the model map each value to its field, separating the amount from phone numbers, transaction ids, fees and balances. Clean named-field services keep the cheap positional path; the header-aware pass only runs on collapsed OCR/text output.

The enrichment step also validates the parsed amount, currency and date against the source document, so a value read from the wrong column gets corrected, with a conservative non-AI guard that rejects obvious identifiers (long leading-zero digit runs).

Fees are no longer discarded. On confirm, a non-zero fee becomes its own expense attributed to a "Charges" party and tagged with a fee intent, so it appears in spending and the party breakdown and still counts against net worth. It is linked back to the transaction it came from only when the import asks for it.

Everything AI-dependent degrades safely: when no AI is configured or its output cannot be parsed, extraction falls back to the previous behavior and imports still complete.

A richer per-row review and a column-remap step are tracked separately as follow-ups.