### PR TITLE
feat(dev): Process the queue in the local docker stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,19 @@ services:
         depends_on:
             - mysql
 
+    worker:
+        image: ghcr.io/whilesmartphp/laravel-dev:8.2
+        # queue:listen (not queue:work) reboots the framework per job so code
+        # edits are picked up without restarting the worker.
+        command: php artisan queue:listen --tries=3 --timeout=120
+        tty: true
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - trakli
+        depends_on:
+            - mysql
+
     mysql:
         image: 'mysql:8.0'
         ports:


### PR DESCRIPTION
Queued work (document import analysis, and anything else dispatched to the queue) never ran on its own locally: the app container serves HTTP only, so a worker had to be started by hand and would silently go stale after a code change. The stack now runs a worker service.

It uses `queue:listen` rather than `queue:work` so the framework reboots per job and code edits take effect without restarting the worker.