### PR TITLE
fix(ci): Bundle the prepared vendor tree into the hosted image

### DIFF
--- a/.github/workflows/build-hosted-image.yml
+++ b/.github/workflows/build-hosted-image.yml
@@ -115,6 +115,10 @@ jobs:
           done
           php artisan plugin:cache
 
+      - name: Keep prepared vendor and plugin cache in the build context
+        run: |
+          sed -i '/^vendor$/d; /^bootstrap\/cache/d' .dockerignore
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -123,7 +127,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push hosted image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/hosted/Dockerfile


### PR DESCRIPTION
The hosted image build failed because the shared ignore rules stripped the vendor directory and plugin cache the runner had just prepared, so the image had nothing to copy. Those are now kept in the build context for the hosted build, and the build step no longer runs on the deprecated Node 20 runtime.