### PR TITLE
feat(ai): Stream chat turns live and cut request latency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,18 @@ DB_USERNAME=trakli
 DB_PASSWORD=secret
 
 BROADCAST_DRIVER=log
+
+# Real-time chat streaming (Laravel Reverb). Set BROADCAST_DRIVER=reverb to enable.
+# In the docker stack the app reaches the server as "reverb"; the browser uses
+# the published host port (REVERB_HOST_PORT, default 6001).
+REVERB_APP_ID=your-reverb-app-id
+REVERB_APP_KEY=your-reverb-app-key
+REVERB_APP_SECRET=generate-a-secure-random-string-here
+REVERB_HOST=reverb
+REVERB_PORT=8080
+REVERB_SCHEME=http
+REVERB_HOST_PORT=6001
+
 CACHE_DRIVER=file
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=sync

--- a/app/Ai/Harnesses/TrakliHarness.php
+++ b/app/Ai/Harnesses/TrakliHarness.php
@@ -21,16 +21,20 @@ class TrakliHarness extends AbstractHarness
     public function systemPrompt(): string
     {
         $rendering = app(UiToolCatalog::class)->systemPromptSection();
+        $today = now()->format('l, j F Y');
 
         return <<<PROMPT
 You are Trakli, a personal finance assistant that can act, not just answer.
+
+Today is {$today}. Resolve any relative date ("last month", "this week",
+"yesterday") from this directly; do not call a tool to learn the date.
 
 Tools:
 - Use `smartql.query` for ANY question about the user's own records (spending,
   income, balances, wallets, categories, parties, transfers). Never guess
   figures: query them.
 - Use `get_stats` for pre-computed analytics (totals, breakdowns, cash flow).
-- Use `clock` before reasoning about relative dates ("last month", "this week").
+- Call `clock` only when you need the exact current time of day, not the date.
 - Use `calculator` for arithmetic instead of computing it yourself.
 
 Context:

--- a/app/Events/ChatTurnEvent.php
+++ b/app/Events/ChatTurnEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * A live update for one chat turn, pushed to the session's private channel as
+ * the assistant works. `progress` carries a step label as each tool runs;
+ * `settled` fires once the answer is saved so the client swaps the progress
+ * view for the result without waiting on a poll.
+ *
+ * Broadcast now (not queued): the emitting job already holds the worker, so a
+ * queued broadcast would not leave the queue until the turn finished, defeating
+ * the point.
+ */
+class ChatTurnEvent implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public int $chatSessionId,
+        public int $messageId,
+        public string $kind,
+        public ?string $label = null,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("chat-session.{$this->chatSessionId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'turn';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'message_id' => $this->messageId,
+            'kind' => $this->kind,
+            'label' => $this->label,
+        ];
+    }
+}

--- a/app/Jobs/GenerateChatTitleJob.php
+++ b/app/Jobs/GenerateChatTitleJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ChatSession;
+use App\Services\AiRouter;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+
+/**
+ * Names a chat session from its opening question. Runs on its own so the extra
+ * model call never sits on the answer's critical path: the assistant reply is
+ * already saved by the time this fires.
+ */
+class GenerateChatTitleJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $timeout = 60;
+
+    public int $tries = 2;
+
+    public function __construct(public ChatSession $session, public string $firstQuestion)
+    {
+    }
+
+    public function handle(AiRouter $router): void
+    {
+        if ($this->session->fresh()?->title !== null) {
+            return;
+        }
+
+        $this->session->update([
+            'title' => $router->generateTitle($this->firstQuestion) ?? Str::limit($this->firstQuestion, 60),
+        ]);
+    }
+}

--- a/app/Jobs/ProcessChatMessageJob.php
+++ b/app/Jobs/ProcessChatMessageJob.php
@@ -14,7 +14,6 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
 use Throwable;
 
 class ProcessChatMessageJob implements ShouldQueue
@@ -66,14 +65,14 @@ class ProcessChatMessageJob implements ShouldQueue
 
         if ($route === AiRouter::ROUTE_GENERAL) {
             $this->answerGeneral($router, $userMessage->content);
-            $this->maybeGenerateTitle($router, $userMessage->content);
+            $this->maybeGenerateTitle($userMessage->content);
 
             return;
         }
 
         if ($route === AiRouter::ROUTE_AGENT) {
             $this->answerAgent($agentRunner, $router, $userMessage);
-            $this->maybeGenerateTitle($router, $userMessage->content);
+            $this->maybeGenerateTitle($userMessage->content);
 
             return;
         }
@@ -92,7 +91,7 @@ class ProcessChatMessageJob implements ShouldQueue
         // fault, so don't tell them to rephrase; say the service is unavailable.
         if (! ($response['success'] ?? false)) {
             $this->answerUnavailable();
-            $this->maybeGenerateTitle($router, $userMessage->content);
+            $this->maybeGenerateTitle($userMessage->content);
 
             return;
         }
@@ -101,7 +100,7 @@ class ProcessChatMessageJob implements ShouldQueue
         $rows = $response['data']['rows'] ?? null;
         if (is_array($rows) && $rows === []) {
             $this->answerGeneral($router, $userMessage->content, __('The data query returned no results.'));
-            $this->maybeGenerateTitle($router, $userMessage->content);
+            $this->maybeGenerateTitle($userMessage->content);
 
             return;
         }
@@ -118,7 +117,7 @@ class ProcessChatMessageJob implements ShouldQueue
             'completed_at' => now(),
         ]);
 
-        $this->maybeGenerateTitle($router, $userMessage->content);
+        $this->maybeGenerateTitle($userMessage->content);
     }
 
     /**
@@ -242,7 +241,7 @@ class ProcessChatMessageJob implements ShouldQueue
         ]);
     }
 
-    private function maybeGenerateTitle(AiRouter $router, string $firstQuestion): void
+    private function maybeGenerateTitle(string $firstQuestion): void
     {
         $session = $this->assistantMessage->session;
 
@@ -259,9 +258,7 @@ class ProcessChatMessageJob implements ShouldQueue
             return;
         }
 
-        $session->update([
-            'title' => $router->generateTitle($firstQuestion) ?? Str::limit($firstQuestion, 60),
-        ]);
+        GenerateChatTitleJob::dispatch($session, $firstQuestion);
     }
 
     private function markFailed(string $error): void

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -57,12 +57,14 @@ class ChatMessage extends Model
         'format_hint',
         'language',
         'result',
+        'progress',
         'error',
         'completed_at',
     ];
 
     protected $casts = [
         'result' => 'array',
+        'progress' => 'array',
         'completed_at' => 'datetime',
     ];
 

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -137,7 +137,7 @@ class Transaction extends Model
         'intent' => 'regular',
     ];
 
-    protected $hidden = ['transfer'];
+    protected $hidden = ['transfer', 'groups', 'recurringTransactionRule', 'refund'];
 
     protected $appends = [
         'wallet',
@@ -176,7 +176,7 @@ class Transaction extends Model
 
     public function getCategoriesAttribute()
     {
-        return $this->categories()->get();
+        return $this->getRelationValue('categories');
     }
 
     public function categories(): MorphToMany
@@ -186,7 +186,7 @@ class Transaction extends Model
 
     public function getWalletAttribute()
     {
-        return $this->wallet()->first();
+        return $this->getRelationValue('wallet');
     }
 
     public function transfer()
@@ -201,7 +201,7 @@ class Transaction extends Model
 
     public function getPartyAttribute()
     {
-        return $this->party()->first();
+        return $this->getRelationValue('party');
     }
 
     public function party()
@@ -216,7 +216,7 @@ class Transaction extends Model
 
     public function getFilesAttribute()
     {
-        return $this->files()->get();
+        return $this->getRelationValue('files');
     }
 
     /**
@@ -229,7 +229,7 @@ class Transaction extends Model
 
     public function getRecurringRulesAttribute()
     {
-        return $this->recurringTransactionRule()->first();
+        return $this->getRelationValue('recurringTransactionRule');
     }
 
     public function recurringTransactionRule(): HasOne
@@ -239,7 +239,7 @@ class Transaction extends Model
 
     public function getIsRefundAttribute(): bool
     {
-        return $this->refund()->exists();
+        return $this->getRelationValue('refund') !== null;
     }
 
     public function getRefundOfTransactionIdAttribute(): ?int

--- a/app/Observers/ChatMessageObserver.php
+++ b/app/Observers/ChatMessageObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Observers;
+
+use App\Events\ChatTurnEvent;
+use App\Models\ChatMessage;
+
+/**
+ * Pushes a "settled" event the moment an assistant reply reaches a terminal
+ * state, so a subscribed client swaps the live progress view for the result
+ * without waiting on the next poll. Covers every answer path (agent, general,
+ * data) uniformly, since they all land here on the same status change.
+ */
+class ChatMessageObserver
+{
+    public function updated(ChatMessage $message): void
+    {
+        if ($message->role !== ChatMessage::ROLE_ASSISTANT) {
+            return;
+        }
+
+        if (! in_array($message->status, [ChatMessage::STATUS_COMPLETED, ChatMessage::STATUS_FAILED], true)) {
+            return;
+        }
+
+        if (! $message->wasChanged('status')) {
+            return;
+        }
+
+        try {
+            ChatTurnEvent::dispatch($message->chat_session_id, $message->id, 'settled');
+        } catch (\Throwable $e) {
+            // A down broadcaster must never break saving the message.
+        }
+    }
+}

--- a/app/Observers/TransactionObserver.php
+++ b/app/Observers/TransactionObserver.php
@@ -60,11 +60,11 @@ class TransactionObserver
 
     protected function updateWalletBalance(Transaction $transaction): void
     {
-        if (! $transaction->wallet || ! is_null($transaction->transfer_id)) {
+        $wallet = $this->freshWalletFor($transaction);
+        if (! $wallet) {
             return;
         }
 
-        $wallet = $transaction->wallet;
         $amount = $transaction->amount;
 
         $wallet->balance += ($transaction->type === 'expense') ? -$amount : $amount;
@@ -73,15 +73,29 @@ class TransactionObserver
 
     protected function revertTransaction(Transaction $transaction): void
     {
-        if (! $transaction->wallet || ! is_null($transaction->transfer_id)) {
+        $wallet = $this->freshWalletFor($transaction);
+        if (! $wallet) {
             return;
         }
 
-        $wallet = $transaction->wallet;
         $amount = $transaction->amount;
 
         $wallet->balance += ($transaction->type === 'expense') ? $amount : -$amount;
         $wallet->save();
+    }
+
+    /**
+     * Balance mutations must read the current persisted wallet, not the
+     * transaction's cached relation, or a stale in-memory balance clobbers a
+     * concurrent revert/update on the same row.
+     */
+    protected function freshWalletFor(Transaction $transaction): ?\App\Models\Wallet
+    {
+        if (! $transaction->wallet_id || ! is_null($transaction->transfer_id)) {
+            return null;
+        }
+
+        return \App\Models\Wallet::find($transaction->wallet_id);
     }
 
     protected function emitRecorded(

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -12,7 +12,9 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Broadcast::routes();
+        // The clients authenticate with a Sanctum bearer token, not a web
+        // session, so the channel-auth endpoint must accept that guard.
+        Broadcast::routes(['middleware' => ['auth:sanctum']]);
 
         require base_path('routes/channels.php');
     }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -12,11 +12,15 @@ use App\Listeners\PasswordResetCompleteListener;
 use App\Listeners\QueueBudgetRecompute;
 use App\Listeners\SendAccountDeletedNotifications;
 use App\Listeners\UserRegistered;
+use App\Models\ChatMessage;
 use App\Models\Transaction;
+use App\Observers\ChatMessageObserver;
+use App\Observers\HoldingObserver;
 use App\Observers\TransactionObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Whilesmart\Holdings\Models\Holding;
 use Whilesmart\UserAuthentication\Events\PasswordResetCodeGeneratedEvent;
 use Whilesmart\UserAuthentication\Events\PasswordResetCompleteEvent;
 use Whilesmart\UserAuthentication\Events\UserRegisteredEvent;
@@ -61,7 +65,8 @@ class EventServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Transaction::observe(TransactionObserver::class);
-        \Whilesmart\Holdings\Models\Holding::observe(\App\Observers\HoldingObserver::class);
+        ChatMessage::observe(ChatMessageObserver::class);
+        Holding::observe(HoldingObserver::class);
     }
 
     /**

--- a/app/Services/AgentRunner.php
+++ b/app/Services/AgentRunner.php
@@ -4,8 +4,11 @@ namespace App\Services;
 
 use App\Ai\BlockBuilder;
 use App\Ai\BlockCollector;
+use App\Events\ChatTurnEvent;
 use App\Models\ChatMessage;
+use Whilesmart\Agents\Enums\StreamEventType;
 use Whilesmart\Agents\Facades\Agents;
+use Whilesmart\Agents\ValueObjects\AgentStreamEvent;
 use Whilesmart\Agents\ValueObjects\ToolContext;
 
 /**
@@ -44,7 +47,12 @@ class AgentRunner
         $collector = new BlockCollector();
         app()->instance(BlockCollector::class, $collector);
 
-        $result = Agents::run('trakli', $this->buildInput($userMessage), $context);
+        $result = Agents::stream(
+            'trakli',
+            $this->buildInput($userMessage),
+            $context,
+            fn (AgentStreamEvent $event) => $this->reportProgress($assistantMessage, $event),
+        );
 
         if (! $result->ok) {
             return ['ok' => false, 'error' => $result->error ?? __('The assistant could not complete the request.')];
@@ -75,6 +83,61 @@ class AgentRunner
             'tool_calls' => $result->toolCalls,
             'usage' => $result->usage,
         ];
+    }
+
+    /**
+     * Append a human-readable step to the assistant message as the agent works,
+     * so a client polling the message shows live progress instead of a spinner.
+     * Consecutive identical labels collapse (the model emits several render_*
+     * calls in a row that all mean "building the report").
+     */
+    private function reportProgress(?ChatMessage $assistantMessage, AgentStreamEvent $event): void
+    {
+        if ($assistantMessage === null || $event->type !== StreamEventType::ToolCall || $event->toolName === null) {
+            return;
+        }
+
+        $label = $this->progressLabel($event->toolName);
+        if ($label === null) {
+            return;
+        }
+
+        $progress = $assistantMessage->progress ?? [];
+        if (end($progress) === $label) {
+            return;
+        }
+
+        $progress[] = $label;
+        $assistantMessage->progress = $progress;
+        $assistantMessage->save();
+
+        // Push the step live; the saved progress remains the poll/reconnect
+        // fallback. A broadcaster that is down must never break the turn.
+        try {
+            ChatTurnEvent::dispatch($assistantMessage->chat_session_id, $assistantMessage->id, 'progress', $label);
+        } catch (\Throwable $e) {
+            // Ignored: streaming is best-effort, the answer still completes.
+        }
+    }
+
+    private function progressLabel(string $tool): ?string
+    {
+        if (str_starts_with($tool, 'render_') || $tool === 'open_canvas' || $tool === 'update_canvas') {
+            return __('Putting your report together');
+        }
+
+        return match ($tool) {
+            'smartql.query' => __('Looking through your records'),
+            'get_stats' => __('Crunching the numbers'),
+            'list_wallets', 'list_categories', 'list_parties' => __('Checking your accounts'),
+            'get_exchange_rate', 'get_asset_price' => __('Fetching current rates'),
+            'calculator' => __('Working out the figures'),
+            'record_transaction', 'record_transfer', 'create_wallet',
+            'create_category', 'create_party', 'categorize_transaction',
+            'attach_to_transaction' => __('Preparing your changes'),
+            'import_document', 'extract_receipt' => __('Reading your document'),
+            default => null,
+        };
     }
 
     /**
@@ -116,7 +179,7 @@ class AgentRunner
                 return "- {$name}{$kind}";
             })->implode("\n");
 
-            $parts[] = "The user attached the following file(s) to this message; "
+            $parts[] = 'The user attached the following file(s) to this message; '
                 . "use the import or receipt tools to process them:\n{$list}";
         }
 

--- a/app/Traits/Groupable.php
+++ b/app/Traits/Groupable.php
@@ -9,12 +9,12 @@ trait Groupable
 {
     public function getGroupsAttribute()
     {
-        return $this->groups()->get();
+        return $this->getRelationValue('groups');
     }
 
     public function getGroupAttribute()
     {
-        return $this->groups()->first();
+        return $this->getRelationValue('groups')->first();
     }
 
     public function groups(): MorphToMany

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "cviebrock/eloquent-sluggable": "^11.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^11.45.1",
+        "laravel/reverb": "^1.10",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "prism-php/prism": "^0.100.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2979e99e43e1df97eb572c40ec5cd166",
+    "content-hash": "48745539c4981a6e8929d5b75fa94001",
     "packages": [
         {
             "name": "beste/clock",
@@ -336,6 +336,136 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "clue/redis-protocol",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/redis-protocol.git",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\Redis\\Protocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A streaming Redis protocol (RESP) parser and serializer written in pure PHP.",
+            "homepage": "https://github.com/clue/redis-protocol",
+            "keywords": [
+                "parser",
+                "protocol",
+                "redis",
+                "resp",
+                "serializer",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/redis-protocol/issues",
+                "source": "https://github.com/clue/redis-protocol/tree/v0.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-07T11:06:28+00:00"
+        },
+        {
+            "name": "clue/redis-react",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-redis.git",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-redis/zipball/84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-protocol": "^0.3.2",
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.0 || ^1.1",
+                "react/promise-timer": "^1.11",
+                "react/socket": "^1.16"
+            },
+            "require-dev": {
+                "clue/block-react": "^1.5",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Redis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Async Redis client implementation, built on top of ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-redis",
+            "keywords": [
+                "async",
+                "client",
+                "database",
+                "reactphp",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-redis/issues",
+                "source": "https://github.com/clue/reactphp-redis/tree/v2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-03T16:18:33+00:00"
         },
         {
             "name": "cocur/slugify",
@@ -933,6 +1063,53 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -2707,6 +2884,85 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.17"
             },
             "time": "2026-04-20T16:07:33+00:00"
+        },
+        {
+            "name": "laravel/reverb",
+            "version": "v1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/reverb.git",
+                "reference": "43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac",
+                "reference": "43a5c0a99b1aaba33dc32f97fcf51f182dd8c8ac",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-react": "^2.6",
+                "guzzlehttp/psr7": "^2.6",
+                "illuminate/console": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.47|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.15|^0.2.0|^0.3.0",
+                "php": "^8.2",
+                "pusher/pusher-php-server": "^7.2",
+                "ratchet/rfc6455": "^0.4",
+                "react/promise-timer": "^1.10",
+                "react/socket": "^1.14",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^6.3|^7.0|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "phpstan/phpstan": "^1.10",
+                "ratchet/pawl": "^0.4.1",
+                "react/async": "^4.2",
+                "react/http": "^1.9"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Reverb\\ApplicationManagerServiceProvider",
+                        "Laravel\\Reverb\\ReverbServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Reverb\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Joe Dixon",
+                    "email": "joe@laravel.com"
+                }
+            ],
+            "description": "Laravel Reverb provides a real-time WebSocket communication backend for Laravel applications.",
+            "keywords": [
+                "WebSockets",
+                "laravel",
+                "real-time",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/reverb/issues",
+                "source": "https://github.com/laravel/reverb/tree/v1.10.2"
+            },
+            "time": "2026-05-10T15:47:52+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -5319,6 +5575,66 @@
             "time": "2026-03-22T23:03:24+00:00"
         },
         {
+            "name": "pusher/pusher-php-server",
+            "version": "7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pusher/pusher-http-php.git",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/4aa139ed2a2a805cd265449b691198beee1309d2",
+                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.2",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "overtrue/phplint": "^2.3",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pusher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library for interacting with the Pusher REST API",
+            "keywords": [
+                "events",
+                "messaging",
+                "php-pusher-server",
+                "publish",
+                "push",
+                "pusher",
+                "real time",
+                "real-time",
+                "realtime",
+                "rest",
+                "trigger"
+            ],
+            "support": {
+                "issues": "https://github.com/pusher/pusher-http-php/issues",
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
+            },
+            "time": "2026-05-18T13:11:36+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -5515,6 +5831,595 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "ratchet/rfc6455",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ratchetphp/RFC6455.git",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/9b05f371219cbaf9748b505f139617dd0715592b",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "psr/http-factory-implementation": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "guzzlehttp/psr7": "^2.7",
+                "phpunit/phpunit": "^9.5",
+                "react/socket": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ratchet\\RFC6455\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Matt Bonneau",
+                    "role": "Developer"
+                }
+            ],
+            "description": "RFC6455 WebSocket protocol handler",
+            "homepage": "http://socketo.me",
+            "keywords": [
+                "WebSockets",
+                "rfc6455",
+                "websocket"
+            ],
+            "support": {
+                "chat": "https://gitter.im/reactphp/reactphp",
+                "issues": "https://github.com/ratchetphp/RFC6455/issues",
+                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.1"
+            },
+            "time": "2026-06-06T14:34:23+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/promise-timer",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise-timer.git",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/4f70306ed66b8b44768941ca7f142092600fafc1",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7.0 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
+            "homepage": "https://github.com/reactphp/promise-timer",
+            "keywords": [
+                "async",
+                "event-loop",
+                "promise",
+                "reactphp",
+                "timeout",
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise-timer/issues",
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:27:45+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "rize/uri-template",
@@ -8797,18 +9702,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/whilesmartphp/eloquent-agents.git",
-                "reference": "f972a6900cadfaf43e3e74dc471e0e5d536e404b"
+                "reference": "8b22831d73002d995a7c65d670084c87d21862fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whilesmartphp/eloquent-agents/zipball/f972a6900cadfaf43e3e74dc471e0e5d536e404b",
-                "reference": "f972a6900cadfaf43e3e74dc471e0e5d536e404b",
+                "url": "https://api.github.com/repos/whilesmartphp/eloquent-agents/zipball/8b22831d73002d995a7c65d670084c87d21862fe",
+                "reference": "8b22831d73002d995a7c65d670084c87d21862fe",
                 "shasum": ""
             },
             "require": {
                 "laravel/framework": "^11.0|^12.0",
                 "php": "^8.2",
-                "prism-php/prism": "^0.100"
+                "prism-php/prism": "^0.99.22|^0.100"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.24",
@@ -8862,7 +9767,7 @@
                 "source": "https://github.com/whilesmartphp/eloquent-agents/tree/main",
                 "issues": "https://github.com/whilesmartphp/eloquent-agents/issues"
             },
-            "time": "2026-06-14T16:23:46+00:00"
+            "time": "2026-07-09T14:18:27+00:00"
         },
         {
             "name": "whilesmart/eloquent-engagement",

--- a/config/app.php
+++ b/config/app.php
@@ -166,7 +166,7 @@ return [
         App\Providers\AppServiceProvider::class,
         App\Providers\OutreachServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
-        // App\Providers\BroadcastServiceProvider::class,
+        App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
     ])->toArray(),

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -30,6 +30,22 @@ return [
 
     'connections' => [
 
+        'reverb' => [
+            'driver' => 'reverb',
+            'key' => env('REVERB_APP_KEY'),
+            'secret' => env('REVERB_APP_SECRET'),
+            'app_id' => env('REVERB_APP_ID'),
+            'options' => [
+                'host' => env('REVERB_HOST'),
+                'port' => env('REVERB_PORT', 443),
+                'scheme' => env('REVERB_SCHEME', 'https'),
+                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+            ],
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+        ],
+
         'pusher' => [
             'driver' => 'pusher',
             'key' => env('PUSHER_APP_KEY'),
@@ -37,7 +53,7 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
+                'host' => env('PUSHER_HOST') ?: 'api-' . env('PUSHER_APP_CLUSTER', 'mt1') . '.pusher.com',
                 'port' => env('PUSHER_PORT', 443),
                 'scheme' => env('PUSHER_SCHEME', 'https'),
                 'encrypted' => true,

--- a/config/cors.php
+++ b/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'paths' => ['api/*', 'broadcasting/auth', 'sanctum/csrf-cookie'],
 
     'allowed_methods' => ['*'],
 

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -1,0 +1,102 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Reverb Server
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default server used by Reverb to handle
+    | incoming messages as well as broadcasting message to all your
+    | connected clients. At this time only "reverb" is supported.
+    |
+    */
+
+    'default' => env('REVERB_SERVER', 'reverb'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Servers
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define details for each of the supported Reverb servers.
+    | Each server has its own configuration options that are defined in
+    | the array below. You should ensure all the options are present.
+    |
+    */
+
+    'servers' => [
+
+        'reverb' => [
+            'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
+            'port' => env('REVERB_SERVER_PORT', 8080),
+            'path' => env('REVERB_SERVER_PATH', ''),
+            'hostname' => env('REVERB_HOST'),
+            'options' => [
+                'tls' => [],
+            ],
+            'max_request_size' => env('REVERB_MAX_REQUEST_SIZE', 10_000),
+            'scaling' => [
+                'enabled' => env('REVERB_SCALING_ENABLED', false),
+                'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
+                'server' => [
+                    'url' => env('REDIS_URL'),
+                    'host' => env('REDIS_HOST', '127.0.0.1'),
+                    'port' => env('REDIS_PORT', '6379'),
+                    'username' => env('REDIS_USERNAME'),
+                    'password' => env('REDIS_PASSWORD'),
+                    'database' => env('REDIS_DB', '0'),
+                    'timeout' => env('REDIS_TIMEOUT', 60),
+                ],
+            ],
+            'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
+            'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Applications
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define how Reverb applications are managed. If you choose
+    | to use the "config" provider, you may define an array of apps which
+    | your server will support, including their connection credentials.
+    |
+    */
+
+    'apps' => [
+
+        'provider' => 'config',
+
+        'apps' => [
+            [
+                'key' => env('REVERB_APP_KEY'),
+                'secret' => env('REVERB_APP_SECRET'),
+                'app_id' => env('REVERB_APP_ID'),
+                'options' => [
+                    'host' => env('REVERB_HOST'),
+                    'port' => env('REVERB_PORT', 443),
+                    'scheme' => env('REVERB_SCHEME', 'https'),
+                    'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                ],
+                'allowed_origins' => ['*'],
+                'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
+                'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
+                'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
+                'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
+                'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
+                'rate_limiting' => [
+                    'enabled' => env('REVERB_APP_RATE_LIMITING_ENABLED', false),
+                    'max_attempts' => env('REVERB_APP_RATE_LIMIT_MAX_ATTEMPTS', 60),
+                    'decay_seconds' => env('REVERB_APP_RATE_LIMIT_DECAY_SECONDS', 60),
+                    'terminate_on_limit' => env('REVERB_APP_RATE_LIMIT_TERMINATE', false),
+                ],
+            ],
+        ],
+
+    ],
+
+];

--- a/database/migrations/2026_07_08_000000_add_progress_to_chat_messages_table.php
+++ b/database/migrations/2026_07_08_000000_add_progress_to_chat_messages_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->json('progress')->nullable()->after('result');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->dropColumn('progress');
+        });
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,22 @@ services:
         depends_on:
             - mysql
 
+    reverb:
+        image: ghcr.io/whilesmartphp/laravel-dev:8.2
+        # The websocket server for real-time chat streaming. The browser
+        # connects on the published port; the app publishes to it over the
+        # trakli network as host "reverb".
+        command: php artisan reverb:start --host=0.0.0.0 --port=8080
+        ports:
+            - '${REVERB_HOST_PORT:-6001}:8080'
+        tty: true
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - trakli
+        depends_on:
+            - mysql
+
     mysql:
         image: 'mysql:8.0'
         ports:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
         <env name="LOG_LEVEL" value="error"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
+        <env name="BROADCAST_DRIVER" value="null"/>
         <env name="DB_DATABASE" value="trakli_test"/>
         <env name="DB_HOST" value="mysql-test"/>
         <env name="MAIL_MAILER" value="array"/>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -16,3 +16,11 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
+
+Broadcast::channel('chat-session.{id}', function ($user, $id) {
+    $session = \App\Models\ChatSession::find($id);
+
+    return $session
+        && $session->owner_type === $user->getMorphClass()
+        && (int) $session->owner_id === (int) $user->getKey();
+});

--- a/tests/Feature/AiChatTest.php
+++ b/tests/Feature/AiChatTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Ai\Tools\Read\SmartqlQueryTool;
 use App\Jobs\ProcessChatMessageJob;
 use App\Models\ChatMessage;
 use App\Models\ChatSession;
@@ -18,6 +19,7 @@ use Mockery;
 use Tests\TestCase;
 use Whilesmart\Agents\Facades\Agents;
 use Whilesmart\Agents\ValueObjects\AgentResult;
+use Whilesmart\Agents\ValueObjects\ToolContext;
 use Whilesmart\Roles\Models\Role;
 
 class AiChatTest extends TestCase
@@ -139,7 +141,7 @@ class AiChatTest extends TestCase
         ]);
 
         $captured = null;
-        Agents::shouldReceive('run')->once()->andReturnUsing(function ($harness, $input) use (&$captured) {
+        Agents::shouldReceive('stream')->once()->andReturnUsing(function ($harness, $input) use (&$captured) {
             $captured = $input;
 
             return AgentResult::success('ok');
@@ -479,8 +481,8 @@ class AiChatTest extends TestCase
             ]),
         ]);
 
-        $tool = app(\App\Ai\Tools\Read\SmartqlQueryTool::class);
-        $context = \Whilesmart\Agents\ValueObjects\ToolContext::forUser($this->user);
+        $tool = app(SmartqlQueryTool::class);
+        $context = ToolContext::forUser($this->user);
 
         $out = $tool->handle(['question' => 'total spent last month'], $context);
 


### PR DESCRIPTION
AI chat and any data or report request felt slow. Profiling the live stack pinned three causes, fixed here.

**The database ran thousands of redundant queries.** Every serialized transaction re-queried its wallet, party, categories, files and group and ignored eager loading, so one stats or transaction-list request ran ~3,700 queries. That collapses to ~40, and the slowest stats section drops from ~1.2s to ~60ms. This also surfaced and fixes a latent wallet-balance bug where a concurrent revert during an amount or wallet change could overwrite the balance.

**Every chat turn spent two extra model calls.** One to learn today's date, one to name the session, both blocking the answer. The date is now given up front and titling runs in the background.

**The turn was fully buffered.** A multi-step agent turn (roughly 30 to 60 seconds on the remote model) showed only a spinner until it finished. It now runs as a stream: each step is recorded on the message and pushed to the browser over the session's private channel as it happens, with a settled event on completion, so the client shows live progress. Broadcasting is best-effort (a down server never breaks a turn) and falls back to the saved progress on poll or reconnect.

Adds the Reverb websocket server to the local stack and consumes the eloquent-agents release that provides run streaming (whilesmartphp/eloquent-agents#4). Paired UI changes: `trakli/webui` branch `feat/ai-chat-improvements`.
