### PR TITLE
docs: Document the tree-name release codename scheme

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,18 @@
+# Release names
+
+Trakli releases are codenamed after **trees**, one per release, walking the
+alphabet from A to Z and then starting over. The version number stays semantic
+(for example `v1.2.0-beta`); the codename is the human name carried in the
+release notes and used to talk about a release.
+
+The same codename is shared across the Trakli repositories (webservice, ui,
+mobile) for a coordinated release, so "Ailanthus" means the same milestone
+everywhere.
+
+| Version | Codename | Notes |
+|---------|----------|-------|
+| v1.2.0-beta | Ailanthus | The AI-forward beta: its name starts with "AI", and the tree is known as the tree of heaven. |
+
+Upcoming letters: Birch, Cedar, Dogwood, Elm, Fir, Ginkgo, Hazel, Ironwood,
+Juniper, Katsura, Larch, Maple, Nyssa, Oak, Pine, Quince, Redwood, Spruce,
+Teak, Ulmus, Viburnum, Willow, Xylosma, Yew, Zelkova.


### PR DESCRIPTION
Establishes the tree-based A-Z codename convention for releases, shared across the Trakli repos. First beta is "Ailanthus" (the tree of heaven; its name starts with "AI" for this AI-forward release).