### PR TITLE
chore(release): Bump to v2.0.0-beta.1 and record the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0-beta] - 2026-07-11
+## [2.0.0-beta.1] - 2026-07-11
 
 Codename: Ailanthus, first of the tree-name series.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta] - 2026-07-11
+
+Codename: Ailanthus, first of the tree-name series.
+
+### Added
+
+- AI assistant that can act, not just answer: confirm-before-write actions, live
+  turn progress streamed over websockets, and canvas reports it can render,
+  update, and export
+- Assistant turns attached documents such as bank statements into reviewable
+  imports
+- Admins can run system-wide AI chat queries
+- Per-user agent token-usage metrics
+- Model Context Protocol server: external AI clients (Claude Desktop, Cursor)
+  read and act on a user's finance data with tokens the user issues, across
+  wallet, transaction, category, party, and stats tools
+- CAMT.053 bank-statement import plugin
+- Statement fees recorded as linked charges on import
+- Intent tagging, financial position, and asset holdings
+- Exchange-rate and asset-price endpoints
+- Entitlements seam for gating features, limits, and metered usage
+- Integrations registry and listing endpoint, with integrations describing their
+  own client UI
+- Admin console with engagement metrics and outreach
+- Admin status exposed in the user payload
+- Delivery: hosted-image build, a per-commit image on merge and latest on
+  release, staging deploys, and local docker queue processing
+
+### Changed
+
+- After you confirm an action, the assistant carries on with your original
+  request and completes the step that needed the new record
+- Smarter statement imports: statement fields are matched by reading the header
+  rather than fixed positions, so values map to the right fields
+- Bulk outreach sends are queued
+- Country preference key renamed to `country`
+
+### Fixed
+
+- SmartQL AI queries are scoped to the requesting tenant
+- Budgets track spend accurately across currencies, using the right conversion
+  rate and direction and auto-converting transactions in another currency
+- Holdings and stats return a consistent response envelope
+- The API docs report the running app version
+- Authenticated requests are rate-limited per user
+
+### Performance
+
+- Faster chat turns: two model round-trips dropped from each turn
+- Faster stats: transaction relations come from already-loaded data, and
+  sections load progressively
+
 ## [1.1.2] - 2026-05-18
 
 ### Fixed

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 Trakli releases are codenamed after **trees**, one per release, walking the
 alphabet from A to Z and then starting over. The version number stays semantic
-(for example `v1.2.0-beta`); the codename is the human name carried in the
+(for example `v2.0.0-beta`); the codename is the human name carried in the
 release notes and used to talk about a release.
 
 The same codename is shared across the Trakli repositories (webservice, ui,
@@ -11,7 +11,7 @@ everywhere.
 
 | Version | Codename | Notes |
 |---------|----------|-------|
-| v1.2.0-beta | Ailanthus | The AI-forward beta: its name starts with "AI", and the tree is known as the tree of heaven. |
+| v2.0.0-beta | Ailanthus | The AI-forward beta: its name starts with "AI", and the tree is known as the tree of heaven. |
 
 Upcoming letters: Birch, Cedar, Dogwood, Elm, Fir, Ginkgo, Hazel, Ironwood,
 Juniper, Katsura, Larch, Maple, Nyssa, Oak, Pine, Quince, Redwood, Spruce,

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "trakli/webservice",
-    "version": "2.0.0-beta",
+    "version": "2.0.0-beta.1",
     "type": "project",
     "description": "Trakli Webservice",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "trakli/webservice",
-    "version": "1.1.2",
+    "version": "2.0.0-beta",
     "type": "project",
     "description": "Trakli Webservice",
     "keywords": [

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Trakli API",
-        "version": "1.1.2"
+        "version": "2.0.0-beta.1"
     },
     "servers": [
         {


### PR DESCRIPTION
Bumps the version to 2.0.0-beta so the pre-release checks run against a fresh tag, records the 2.0.0-beta changelog, and corrects the RELEASES.md codename entry to v2.0.0-beta "Ailanthus". Must land on dev before the dev-to-main release PR (#289) can pass pre-release checks.