### PR TITLE
fix(ai): Read a receipt as one transaction with its merchant

### DIFF
--- a/app/Ai/Tools/Documents/ExtractReceiptTool.php
+++ b/app/Ai/Tools/Documents/ExtractReceiptTool.php
@@ -4,7 +4,10 @@ namespace App\Ai\Tools\Documents;
 
 use App\Ai\Tools\ResolvesChatAttachment;
 use App\Ai\Tools\Write\RecordTransactionTool;
+use App\Models\User;
 use App\Services\DocumentProcessorManager;
+use App\Services\DocumentProcessors\RemoteDocumentProcessor;
+use App\Types\TransactionSuggestion;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
@@ -57,24 +60,59 @@ class ExtractReceiptTool extends RecordTransactionTool
             throw new InvalidArgumentException('That file type cannot be read as a receipt.');
         }
 
-        $uploaded = new UploadedFile(Storage::path($path), basename($path), $mimeType, null, true);
-        $suggestions = $this->processors->getProcessor($mimeType, $extension)->process($uploaded, $user);
+        $processor = $this->processors->getProcessor($mimeType, $extension);
+        if (! $processor instanceof RemoteDocumentProcessor) {
+            throw new InvalidArgumentException('That file type cannot be read as a receipt.');
+        }
 
-        $suggestion = $suggestions[0] ?? null;
-        if (! is_array($suggestion) || empty($suggestion['amount'])) {
+        $uploaded = new UploadedFile(Storage::path($path), basename($path), $mimeType, null, true);
+        $suggestion = $processor->extractReceipt($uploaded);
+        if ($suggestion === null || ! $suggestion->amount) {
             throw new InvalidArgumentException('Could not read a transaction from that receipt.');
         }
 
-        // Default to the user's first wallet so confirm works; the user can change
-        // it in the review form.
-        $walletId = $user->wallets()->value('id');
+        return parent::buildPayload($this->receiptArguments($user, $suggestion), $context);
+    }
 
-        return array_filter([
-            'amount' => (float) $suggestion['amount'],
-            'type' => in_array($suggestion['type'] ?? null, ['income', 'expense'], true) ? $suggestion['type'] : 'expense',
-            'wallet_id' => $walletId,
-            'description' => $suggestion['description'] ?? 'Receipt',
-            'datetime' => $suggestion['date'] ?? null,
-        ], fn ($value) => $value !== null);
+    /**
+     * Turn the extracted receipt into RecordTransactionTool arguments. The store
+     * becomes the party only when it already exists (the resolver rejects an
+     * unknown one); otherwise it stays in the description.
+     *
+     * @return array<string, mixed>
+     */
+    private function receiptArguments(User $user, TransactionSuggestion $suggestion): array
+    {
+        $description = trim((string) $suggestion->description);
+
+        // Default to the user's first wallet so confirm works; the user can
+        // change it in the review form.
+        $args = [
+            'amount' => $suggestion->amount,
+            'type' => 'expense',
+            'wallet_id' => $user->wallets()->value('id'),
+            'datetime' => $suggestion->date,
+        ];
+
+        $merchant = trim((string) $suggestion->party);
+        if ($merchant !== '') {
+            $party = $user->parties()->whereRaw('LOWER(name) = ?', [mb_strtolower($merchant)])->first();
+            if ($party !== null) {
+                $args['party_id'] = $party->id;
+            } elseif ($description === '') {
+                $description = $merchant;
+            } else {
+                $description = "{$merchant}: {$description}";
+            }
+        }
+
+        $args['description'] = $description === '' ? 'Receipt' : $description;
+
+        $category = trim((string) $suggestion->category);
+        if ($category !== '' && $user->categories()->whereRaw('LOWER(name) = ?', [mb_strtolower($category)])->exists()) {
+            $args['category_names'] = [$category];
+        }
+
+        return $args;
     }
 }

--- a/app/Services/DocumentProcessors/ParsesLlmData.php
+++ b/app/Services/DocumentProcessors/ParsesLlmData.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\DocumentProcessors;
+
+use Carbon\Carbon;
+
+trait ParsesLlmData
+{
+    private function parseLlmJson(string $text): ?array
+    {
+        $text = trim($text);
+
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text);
+            $text = preg_replace('/\s*```$/', '', $text);
+        }
+
+        $decoded = json_decode($text, true);
+
+        return (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) ? $decoded : null;
+    }
+
+    private function normalizeDate(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            return $value;
+        }
+
+        // Remove commas that confuse Carbon (e.g. "05 Apr, 2024" → "05 Apr 2024")
+        $value = str_replace(',', '', $value);
+
+        try {
+            return Carbon::parse($value)->format('Y-m-d');
+        } catch (\Exception) {
+            return null;
+        }
+    }
+}

--- a/app/Services/DocumentProcessors/ReceiptReader.php
+++ b/app/Services/DocumentProcessors/ReceiptReader.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\DocumentProcessors;
+
+use App\Types\TransactionSuggestion;
+use Illuminate\Support\Facades\Log;
+use Prism\Prism\Facades\Prism;
+
+/**
+ * Reads a store/shop receipt as a single purchase: the printed grand total, the
+ * merchant, date and a spending category. Deliberately not the generic
+ * "find every transaction" extraction, which returns one row per line item.
+ */
+class ReceiptReader
+{
+    use ParsesLlmData;
+
+    public function read(string $rawText): ?TransactionSuggestion
+    {
+        $provider = config('services.llm.provider', 'groq');
+        $model = config('services.llm.model', 'llama-3.1-8b-instant');
+
+        try {
+            $llm = Prism::text()
+                ->using($provider, $model)
+                ->withSystemPrompt(<<<'PROMPT'
+You are a receipt parser. The text is one store or shop receipt for a single
+purchase. Return ONLY a valid JSON object (no markdown, no other text) with keys:
+- amount: number, the receipt's printed grand total (what was actually paid), not the sum of line items
+- merchant: string, the store or shop name, or null
+- date: string in YYYY-MM-DD format, or null
+- category: string, a spending category for the purchase (e.g. Groceries, Dining, Fuel), or null
+- description: short string of what was bought, or null
+- currency: 3-letter currency code, or null
+Use null for anything you cannot determine.
+PROMPT)
+                ->withPrompt("Parse this receipt:\n\n" . $rawText)
+                ->usingTemperature(0)
+                ->asText();
+
+            $data = $this->parseLlmJson($llm->text);
+            if (! is_array($data)) {
+                return null;
+            }
+            if (isset($data[0]) && is_array($data[0])) {
+                $data = $data[0];
+            }
+
+            $amount = $data['amount'] ?? null;
+            if ($amount === null || (float) $amount <= 0) {
+                return null;
+            }
+
+            return new TransactionSuggestion(
+                amount: abs((float) $amount),
+                currency: $data['currency'] ?? null,
+                type: 'expense',
+                party: $data['merchant'] ?? null,
+                category: $data['category'] ?? null,
+                description: $data['description'] ?? null,
+                date: $this->normalizeDate($data['date'] ?? null),
+                confidence: 0.6,
+                documentType: 'receipt',
+            );
+        } catch (\Throwable $e) {
+            Log::warning('ReceiptReader: extraction failed', ['error' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+}

--- a/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
+++ b/app/Services/DocumentProcessors/RemoteDocumentProcessor.php
@@ -7,7 +7,6 @@ use App\Contracts\ProvidesExtractionContext;
 use App\Models\User;
 use App\Services\StatementStructurer;
 use App\Types\TransactionSuggestion;
-use Carbon\Carbon;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
@@ -39,6 +38,8 @@ use Prism\Prism\Facades\Prism;
  */
 class RemoteDocumentProcessor implements DocumentProcessor, ProvidesExtractionContext
 {
+    use ParsesLlmData;
+
     private const SUPPORTED_EXTENSIONS = ['pdf', 'png', 'jpg', 'jpeg', 'tiff', 'tif', 'bmp'];
 
     private ?string $lastContext = null;
@@ -368,28 +369,6 @@ class RemoteDocumentProcessor implements DocumentProcessor, ProvidesExtractionCo
         return $val !== '' ? $val : null;
     }
 
-    private function normalizeDate(?string $value): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $value = trim($value);
-
-        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
-            return $value;
-        }
-
-        // Remove commas that confuse Carbon (e.g. "05 Apr, 2024" → "05 Apr 2024")
-        $value = str_replace(',', '', $value);
-
-        try {
-            return Carbon::parse($value)->format('Y-m-d');
-        } catch (\Exception) {
-            return null;
-        }
-    }
-
     /**
      * Extract all readable text from the processor response for LLM fallback.
      */
@@ -498,17 +477,23 @@ PROMPT)
         }
     }
 
-    private function parseLlmJson(string $text): ?array
+    /**
+     * Read a store/shop receipt as a single purchase (printed total, merchant,
+     * date, category), not the generic per-line-item extraction.
+     */
+    public function extractReceipt(UploadedFile $file): ?TransactionSuggestion
     {
-        $text = trim($text);
-
-        if (str_starts_with($text, '```')) {
-            $text = preg_replace('/^```(?:json)?\s*/', '', $text);
-            $text = preg_replace('/\s*```$/', '', $text);
+        if (empty(config('services.document_processor.url'))) {
+            return null;
         }
 
-        $decoded = json_decode($text, true);
+        $response = $this->callRemote($file);
+        if ($response === null) {
+            return null;
+        }
 
-        return (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) ? $decoded : null;
+        $rawText = mb_substr($this->extractRawText($response), 0, 8000);
+
+        return $rawText === '' ? null : (new ReceiptReader())->read($rawText);
     }
 }

--- a/tests/Feature/AgentReceiptAttachTest.php
+++ b/tests/Feature/AgentReceiptAttachTest.php
@@ -3,16 +3,13 @@
 namespace Tests\Feature;
 
 use App\Ai\BlockCollector;
-use App\Ai\Tools\Documents\ExtractReceiptTool;
 use App\Ai\Tools\Write\AttachToTransactionTool;
-use App\Contracts\DocumentProcessor;
 use App\Models\AgentProposedAction;
 use App\Models\ChatMessage;
 use App\Models\ChatSession;
 use App\Models\Transaction;
 use App\Models\User;
 use App\Models\Wallet;
-use App\Services\DocumentProcessorManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
@@ -65,28 +62,5 @@ class AgentReceiptAttachTest extends TestCase
             ->assertStatus(200);
 
         $this->assertSame(1, $transaction->fresh()->files()->count());
-    }
-
-    public function test_extract_receipt_proposes_a_transaction_from_the_first_suggestion(): void
-    {
-        $this->attachFileToChat();
-
-        $processor = \Mockery::mock(DocumentProcessor::class);
-        $processor->shouldReceive('process')->andReturn([
-            ['amount' => 12.5, 'type' => 'expense', 'description' => 'Coffee shop', 'date' => '2026-06-01'],
-        ]);
-        $manager = \Mockery::mock(DocumentProcessorManager::class);
-        $manager->shouldReceive('canHandle')->andReturn(true);
-        $manager->shouldReceive('getProcessor')->andReturn($processor);
-        $this->app->instance(DocumentProcessorManager::class, $manager);
-        $this->app->instance(BlockCollector::class, new BlockCollector());
-
-        $this->app->make(ExtractReceiptTool::class)->handle([], $this->context());
-
-        $action = AgentProposedAction::latest('id')->firstOrFail();
-        $this->assertSame('transaction.create', $action->action_type);
-        $this->assertEquals(12.5, $action->payload['amount']);
-        $this->assertEquals('Coffee shop', $action->payload['description']);
-        $this->assertEquals($this->wallet->id, $action->payload['wallet_id']);
     }
 }

--- a/tests/Feature/ReceiptExtractionTest.php
+++ b/tests/Feature/ReceiptExtractionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Ai\BlockCollector;
+use App\Ai\Tools\Documents\ExtractReceiptTool;
+use App\Models\AgentProposedAction;
+use App\Models\Category;
+use App\Models\ChatMessage;
+use App\Models\ChatSession;
+use App\Models\Party;
+use App\Models\User;
+use App\Models\Wallet;
+use App\Services\DocumentProcessorManager;
+use App\Services\DocumentProcessors\RemoteDocumentProcessor;
+use App\Types\TransactionSuggestion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Tests\TestCase;
+use Whilesmart\Agents\ValueObjects\ToolContext;
+
+class ReceiptExtractionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private ChatSession $session;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        Wallet::factory()->create(['user_id' => $this->user->id]);
+        $this->session = ChatSession::create([
+            'owner_type' => $this->user->getMorphClass(),
+            'owner_id' => $this->user->id,
+        ]);
+    }
+
+    private function proposeReceipt(TransactionSuggestion $suggestion): AgentProposedAction
+    {
+        Storage::fake('local');
+        Storage::put('chat_attachments/receipt.jpg', 'img');
+        $message = $this->session->messages()->create([
+            'user_id' => $this->user->id,
+            'role' => ChatMessage::ROLE_USER,
+            'content' => 'Attached receipt.jpg',
+        ]);
+        $message->files()->create(['path' => 'chat_attachments/receipt.jpg', 'type' => 'image']);
+
+        $processor = Mockery::mock(RemoteDocumentProcessor::class);
+        $processor->shouldReceive('extractReceipt')->once()->andReturn($suggestion);
+
+        $manager = Mockery::mock(DocumentProcessorManager::class);
+        $manager->shouldReceive('canHandle')->andReturn(true);
+        $manager->shouldReceive('getProcessor')->andReturn($processor);
+
+        $this->app->instance(DocumentProcessorManager::class, $manager);
+        $this->app->instance(BlockCollector::class, new BlockCollector());
+
+        $this->app->make(ExtractReceiptTool::class)->handle(
+            [],
+            ToolContext::forUser($this->user, 'en', ['chat_session_id' => $this->session->id]),
+        );
+
+        return AgentProposedAction::latest('id')->firstOrFail();
+    }
+
+    public function test_a_receipt_proposes_one_expense_with_the_printed_total(): void
+    {
+        $action = $this->proposeReceipt(new TransactionSuggestion(
+            amount: 42.50,
+            type: 'expense',
+            party: 'Corner Store',
+            category: null,
+            description: 'Groceries',
+            date: '2026-07-01',
+        ));
+
+        $this->assertSame('transaction.create', $action->action_type);
+        $this->assertEquals(42.50, (float) $action->payload['amount']);
+        $this->assertSame('expense', $action->payload['type']);
+        // An unknown merchant is kept in the description, not dropped.
+        $this->assertStringContainsString('Corner Store', $action->payload['description']);
+        $this->assertArrayNotHasKey('party_id', $action->payload);
+    }
+
+    public function test_a_known_merchant_and_category_are_attached(): void
+    {
+        $party = Party::factory()->create(['user_id' => $this->user->id, 'name' => 'Walmart']);
+        $category = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Groceries']);
+
+        $action = $this->proposeReceipt(new TransactionSuggestion(
+            amount: 88.00,
+            type: 'expense',
+            party: 'Walmart',
+            category: 'Groceries',
+            description: 'weekly shop',
+            date: '2026-07-02',
+        ));
+
+        $this->assertEquals($party->id, $action->payload['party_id']);
+        $this->assertContains($category->id, $action->payload['categories']);
+    }
+}


### PR DESCRIPTION
Attaching a shop receipt didn't work: the extractor's result was read as an array when it is an object (so it always failed), and the generic extractor treats a receipt like a statement, returning a row per line item.

Receipts now read the printed total as a single expense and attach the store as the party and a spending category when those already exist, then go through the existing review-and-confirm flow.
