### PR TITLE
fix: Sync deletions, keep transfer decimals, and reject zero amount imports

### DIFF
--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -727,7 +727,7 @@ class TransactionController extends ApiController
                 }
 
                 $user = $request->user();
-                if (isset($request['client_id']) && ! $transaction->client_id) {
+                if (isset($request['client_id']) && ! $transaction->client_generated_id) {
                     $transaction->setClientGeneratedId($request['client_id'], $user);
                 }
 

--- a/app/Http/Controllers/API/v1/TransferController.php
+++ b/app/Http/Controllers/API/v1/TransferController.php
@@ -223,7 +223,13 @@ class TransferController extends ApiController
             $exchangeRate = $data['exchange_rate'];
         }
 
-        $amountToReceive = bcmul($data['amount'], $exchangeRate);
+        // bcmul's default scale is 0, which would truncate the received amount
+        // to a whole number; 4 matches the amount and balance column scales.
+        $amountToReceive = bcmul(sprintf('%.8F', $data['amount']), sprintf('%.8F', $exchangeRate), 4);
+
+        if (bccomp($amountToReceive, '0', 4) <= 0) {
+            return $this->failure(__('The amount received rounds to zero at this exchange rate'), 422);
+        }
 
         $datetime = isset($data['datetime']) ? format_iso8601_to_sql($data['datetime']) : null;
 

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -129,7 +129,9 @@ class Transaction extends Model
      */
     protected $casts = [
         'datetime' => 'datetime',
-        'amount' => 'decimal:2',
+        // Matches the column scale; 2 would round sub-cent amounts
+        // (crypto transfer legs) in every response.
+        'amount' => 'decimal:4',
         'metadata' => 'array',
     ];
 

--- a/app/Services/FileImportService.php
+++ b/app/Services/FileImportService.php
@@ -89,8 +89,8 @@ class FileImportService
                         );
                         Log::error($e);
                     }
-                } elseif ($transactionType == '+Transfer') {
-                    if (isset($csvData[$i + 1]) && $csvData[$i + 1][2] == '-Transfer') {
+                } elseif ($transactionType == '+transfer') {
+                    if (isset($csvData[$i + 1]) && strtolower(trim($csvData[$i + 1][2])) == '-transfer') {
                         try {
                             $this->importTransfer($data, $csvData[$i + 1], $user);
                         } catch (FileImportException $e) {
@@ -190,6 +190,9 @@ class FileImportService
             // get the data we need
 
             $amount = floatval($data[0]);
+            if ($amount <= 0) {
+                throw new FileImportException(__('Amount must be a number greater than zero'));
+            }
             $currency = $data[1];
             $party = $data[3];
             $wallet = $data[4];
@@ -282,6 +285,11 @@ class FileImportService
         bool $linkFee = false,
     ): void {
         DB::transaction(function () use ($merged, $transactionType, $user, $autoCreateWallets, $autoCreateParties, $autoCreateCategories, $linkFee) {
+            $amount = (float) ($merged['amount'] ?? 0);
+            if ($amount <= 0) {
+                throw new FileImportException(__('Amount must be a number greater than zero'));
+            }
+
             $wallet = $this->resolveWalletForConfirm(
                 $user,
                 $merged['wallet_id'] ?? null,
@@ -304,7 +312,7 @@ class FileImportService
             );
 
             $transaction = $user->transactions()->create([
-                'amount' => (float) ($merged['amount'] ?? 0),
+                'amount' => $amount,
                 'description' => $merged['description'] ?? null,
                 'datetime' => $merged['date'] ?? null,
                 'type' => $transactionType,

--- a/app/Traits/Syncable.php
+++ b/app/Traits/Syncable.php
@@ -17,6 +17,14 @@ trait Syncable
                 'last_synced_at' => now(),
             ]);
         });
+
+        // Only soft deletes leave a row behind to sync; a hard delete would
+        // just recreate an orphaned sync state here.
+        static::deleted(function ($model) {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+                $model->markAsSynced();
+            }
+        });
     }
 
     public function syncState()

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "whilesmart/eloquent-agent-metrics": "^1.0",
         "whilesmart/eloquent-agents": "^1.0",
         "whilesmart/eloquent-engagement": "dev-dev",
-        "whilesmart/eloquent-holdings": "^1.1",
+        "whilesmart/eloquent-holdings": "^1.2",
         "whilesmart/eloquent-model-configuration": "^1.0.9",
         "whilesmart/eloquent-outreach": "dev-dev",
         "whilesmart/eloquent-roles": "dev-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c82fbdfce5507513762c2c5118bfa068",
+    "content-hash": "d1dc07527b91bc2fc41288ed8c31bd47",
     "packages": [
         {
             "name": "beste/clock",
@@ -10074,16 +10074,16 @@
         },
         {
             "name": "whilesmart/eloquent-holdings",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/whilesmartphp/eloquent-holdings.git",
-                "reference": "9aa77fe5deb6da0d08d7c2234ffa1b03a888afd2"
+                "reference": "c921cf5d696bde6d71784f17a8b9d3e1fdd606d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whilesmartphp/eloquent-holdings/zipball/9aa77fe5deb6da0d08d7c2234ffa1b03a888afd2",
-                "reference": "9aa77fe5deb6da0d08d7c2234ffa1b03a888afd2",
+                "url": "https://api.github.com/repos/whilesmartphp/eloquent-holdings/zipball/c921cf5d696bde6d71784f17a8b9d3e1fdd606d5",
+                "reference": "c921cf5d696bde6d71784f17a8b9d3e1fdd606d5",
                 "shasum": ""
             },
             "require": {
@@ -10122,9 +10122,9 @@
             "description": "Polymorphic holdings register (crypto, stocks, property, any asset) for Laravel: track quantity and value, with pluggable live pricing.",
             "support": {
                 "issues": "https://github.com/whilesmartphp/eloquent-holdings/issues",
-                "source": "https://github.com/whilesmartphp/eloquent-holdings/tree/v1.1.0"
+                "source": "https://github.com/whilesmartphp/eloquent-holdings/tree/v1.2.0"
             },
-            "time": "2026-07-04T21:10:17+00:00"
+            "time": "2026-07-22T12:38:29+00:00"
         },
         {
             "name": "whilesmart/eloquent-model-configuration",

--- a/tests/Feature/AdvancedImportTest.php
+++ b/tests/Feature/AdvancedImportTest.php
@@ -824,6 +824,27 @@ class AdvancedImportTest extends TestCase
     // Helpers
     // ---------------------------------------------------------------------
 
+    public function test_confirm_rejects_a_zero_amount_suggestion(): void
+    {
+        $wallet = $this->user->wallets()->create(['name' => 'Checking', 'currency' => 'USD']);
+
+        $session = $this->makeReadySession([
+            $this->sampleSuggestion(['amount' => 0, 'type' => 'expense']),
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/import/confirm', [
+            'session_id' => $session->id,
+            'accepted' => [['index' => 0, 'wallet_id' => $wallet->id]],
+        ]);
+
+        $response->assertStatus(206);
+
+        $data = $response->json('data');
+        $this->assertEquals(0, $data['created_count']);
+        $this->assertNotEmpty($data['errors']);
+        $this->assertEquals(0, $this->user->transactions()->count());
+    }
+
     private function makeReadySession(array $suggestions): \App\Models\ImportSession
     {
         return $this->user->importSessions()->create([

--- a/tests/Feature/HoldingsIntegrationTest.php
+++ b/tests/Feature/HoldingsIntegrationTest.php
@@ -69,6 +69,24 @@ class HoldingsIntegrationTest extends TestCase
             ->assertStatus(403);
     }
 
+    public function test_creating_an_auto_holding_prices_it_from_coingecko_immediately()
+    {
+        Http::fake([
+            'api.coingecko.com/api/v3/simple/price*' => Http::response(['bitcoin' => ['usd' => 70000]], 200),
+        ]);
+
+        $payload = $this->ownerPayload([
+            'price_source' => 'auto', 'provider' => 'coingecko', 'external_ref' => 'bitcoin',
+        ]);
+        unset($payload['unit_price']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/holdings', $payload);
+
+        $response->assertStatus(201);
+        $this->assertEquals(70000, $response->json('data.unit_price'));
+        $this->assertNotNull($response->json('data.last_priced_at'));
+    }
+
     public function test_reprice_updates_auto_holdings_via_coingecko()
     {
         Http::fake([

--- a/tests/Feature/ImportTest.php
+++ b/tests/Feature/ImportTest.php
@@ -72,6 +72,34 @@ class ImportTest extends TestCase
         return $data;
     }
 
+    public function test_api_csv_rows_with_non_positive_amounts_fail_instead_of_importing()
+    {
+        $content = "amount,currency,type,party,wallet,category,description,date\n".
+            "0,USD,expense,John Doe,Wallet1,Food,Zero row,2023-01-01\n".
+            'abc,USD,expense,John Doe,Wallet1,Food,Junk row,2023-01-01';
+        $this->uploadCsv($content);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/imports');
+        $response->assertStatus(200);
+        $this->assertEquals(2, $response->json('data')[0]['failed_imports_count']);
+        $this->assertEquals(0, $this->user->transactions()->count());
+    }
+
+    public function test_api_csv_transfer_rows_import_as_a_transfer()
+    {
+        $content = "amount,currency,type,party,wallet,category,description,date\n".
+            "100,USD,+Transfer,,Wallet1,,Transfer out,2023-01-01\n".
+            '100,USD,-Transfer,,Wallet2,,Transfer in,2023-01-01';
+        $this->uploadCsv($content);
+
+        $response = $this->actingAs($this->user)->getJson('/api/v1/imports');
+        $response->assertStatus(200);
+        $this->assertEquals(0, $response->json('data')[0]['failed_imports_count']);
+
+        $this->assertEquals(1, $this->user->transfers()->count());
+        $this->assertEquals(2, $this->user->transactions()->count());
+    }
+
     public function test_api_user_can_get_scheduled_imports()
     {
         $import = $this->uploadCsv();

--- a/tests/Feature/SyncableModelsTest.php
+++ b/tests/Feature/SyncableModelsTest.php
@@ -4,11 +4,13 @@ namespace Tests\Feature;
 
 use App\Models\Category;
 use App\Models\Group;
+use App\Models\ModelSyncState;
 use App\Models\Party;
 use App\Models\Transaction;
 use App\Models\Transfer;
 use App\Models\User;
 use App\Models\Wallet;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -103,5 +105,71 @@ class SyncableModelsTest extends TestCase
 
         $this->assertEquals('The updated at date is less than the created at date', $message);
 
+    }
+
+    /** @test */
+    public function soft_deleting_a_transaction_over_the_api_updates_last_synced_at()
+    {
+        $user = User::factory()->create();
+        $wallet = Wallet::factory()->create(['user_id' => $user->id]);
+
+        /** @var Transaction */
+        $transaction = Transaction::factory()->create([
+            'user_id' => $user->id,
+            'wallet_id' => $wallet->id,
+        ]);
+
+        $before = Carbon::parse($transaction->syncState->last_synced_at);
+        $this->travel(5)->minutes();
+
+        $this->actingAs($user)
+            ->deleteJson('/api/v1/transactions/' . $transaction->id)
+            ->assertStatus(200);
+
+        $state = ModelSyncState::where('syncable_type', Transaction::class)
+            ->where('syncable_id', $transaction->id)
+            ->first();
+
+        $this->assertTrue(Carbon::parse($state->last_synced_at)->gt($before));
+    }
+
+    /** @test */
+    public function soft_deleting_a_wallet_over_the_api_updates_last_synced_at()
+    {
+        $user = User::factory()->create();
+        $wallet = Wallet::factory()->create(['user_id' => $user->id]);
+
+        $before = Carbon::parse($wallet->syncState->last_synced_at);
+        $this->travel(5)->minutes();
+
+        $this->actingAs($user)
+            ->deleteJson('/api/v1/wallets/' . $wallet->id)
+            ->assertStatus(200);
+
+        $state = ModelSyncState::where('syncable_type', Wallet::class)
+            ->where('syncable_id', $wallet->id)
+            ->first();
+
+        $this->assertTrue(Carbon::parse($state->last_synced_at)->gt($before));
+    }
+
+    /** @test */
+    public function soft_deleting_a_category_over_the_api_updates_last_synced_at()
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->create(['user_id' => $user->id]);
+
+        $before = Carbon::parse($category->syncState->last_synced_at);
+        $this->travel(5)->minutes();
+
+        $this->actingAs($user)
+            ->deleteJson('/api/v1/categories/' . $category->id)
+            ->assertStatus(204);
+
+        $state = ModelSyncState::where('syncable_type', Category::class)
+            ->where('syncable_id', $category->id)
+            ->first();
+
+        $this->assertTrue(Carbon::parse($state->last_synced_at)->gt($before));
     }
 }

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -936,6 +936,47 @@ class TransactionsTest extends TestCase
         $this->assertEquals("$deviceToken:$clientId", $response->json('data.client_generated_id'));
     }
 
+    public function test_api_user_can_attach_a_client_id_with_a_client_id_only_update()
+    {
+        $expense = $this->createTransaction('expense');
+        $clientId = '245cb3df-df3a-428b-a908-e5f74b8d58a5';
+        $deviceToken = '245cb3df-df3a-428b-a908-e5f74b8d58a4';
+
+        $response = $this->actingAs($this->user)->putJson('/api/v1/transactions/' . $expense['id'], [
+            'client_id' => "$deviceToken:$clientId",
+        ]);
+
+        $response->assertStatus(200);
+
+        $transaction = Transaction::find($expense['id']);
+        $this->assertEquals($clientId, $transaction->syncState->client_generated_id);
+        $this->assertEquals(100, $transaction->amount);
+    }
+
+    public function test_api_updating_with_a_new_client_id_does_not_overwrite_the_existing_one()
+    {
+        $deviceToken = '245cb3df-df3a-428b-a908-e5f74b8d58a4';
+        $originalClientId = '245cb3df-df3a-428b-a908-e5f74b8d58a5';
+
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'party_id' => $this->party->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'client_id' => "$deviceToken:$originalClientId",
+        ]);
+        $response->assertStatus(201);
+        $transactionId = $response->json('data.id');
+
+        $this->actingAs($this->user)->putJson('/api/v1/transactions/' . $transactionId, [
+            'client_id' => "$deviceToken:245cb3df-df3a-428b-a908-e5f74b8d58a6",
+        ])->assertStatus(200);
+
+        $transaction = Transaction::find($transactionId);
+        $this->assertEquals($originalClientId, $transaction->syncState->client_generated_id);
+    }
+
     public function test_api_user_cannot_create_transaction_with_invalid_client_id_format()
     {
         // Test with client_id that has no colon

--- a/tests/Feature/TransferTest.php
+++ b/tests/Feature/TransferTest.php
@@ -185,6 +185,63 @@ class TransferTest extends TestCase
         $response->assertStatus(422);
     }
 
+    public function test_transfer_preserves_decimals_in_the_received_amount()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000]);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 0]);
+
+        $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 100.75,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+        ])->assertStatus(201);
+
+        $toWallet->refresh();
+        $this->assertEquals(100.75, $toWallet->balance);
+
+        $incomeTransaction = Transaction::where('wallet_id', $toWallet->id)->first();
+        $this->assertEquals(100.75, $incomeTransaction->amount);
+    }
+
+    public function test_cross_currency_transfer_keeps_a_fractional_received_amount()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000, 'currency' => 'USD']);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 0, 'currency' => 'BTC']);
+
+        $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 50,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+            'exchange_rate' => 0.0005,
+        ])->assertStatus(201);
+
+        $toWallet->refresh();
+        $this->assertEquals(0.025, $toWallet->balance);
+
+        $incomeTransaction = Transaction::where('wallet_id', $toWallet->id)->first();
+        $this->assertEquals(0.025, $incomeTransaction->amount);
+    }
+
+    public function test_transfer_fails_when_the_received_amount_rounds_to_zero()
+    {
+        $user = User::factory()->create();
+        $fromWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 1000, 'currency' => 'USD']);
+        $toWallet = Wallet::factory()->create(['user_id' => $user->id, 'balance' => 0, 'currency' => 'BTC']);
+
+        $response = $this->actingAs($user)->postJson('/api/v1/transfers', [
+            'amount' => 0.01,
+            'from_wallet_id' => $fromWallet->id,
+            'to_wallet_id' => $toWallet->id,
+            'exchange_rate' => 0.001,
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertEquals(0, Transfer::count());
+        $this->assertEquals(1000, $fromWallet->refresh()->balance);
+    }
+
     public function test_transfer_with_client_id_stores_sync_state()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Fixes a cluster of data integrity bugs that surfaced through mobile sync.

- Deleting a record left its sync timestamp at the pre-delete value, so clients comparing timestamps treated the tombstone as unchanged and never applied the deletion.
- The received amount of a transfer was computed at bcmath's default scale of 0. Cents vanished on every transfer, and a fiat to crypto conversion created a zero amount transaction. Those zero rows then failed the update endpoint's minimum amount rule, which also blocked attaching a client id and stalled sync of anything referencing them. Transfers whose received amount rounds to zero are now rejected.
- Responses rounded amounts to two decimals while the column stores four, so a 0.025 BTC transfer leg read as 0.03.
- Imports accepted rows with zero or unparseable amounts and imported them as zero amount transactions.
- CSV transfer rows were compared against their marker after lowercasing, so they could never match and every transfer in a file failed as an invalid type.
- The update guard for client ids checked an attribute that does not exist, so a second device could silently overwrite the first device's mapping.

Legacy zero amount rows still need a data repair before full-record updates succeed; a client-id-only update already passes, so the mobile client should send that instead of echoing the full record.

The reported $0 unit price on live-priced holdings is fixed in whilesmartphp/eloquent-holdings#4; this PR picks up 1.2.0, so live-priced holdings come back priced in the create response.
