### PR TITLE
docs: Rewrite the readme pitch to match the site copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,40 @@
 [![Tests](https://github.com/trakli/webservice/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/trakli/webservice/actions/workflows/tests.yml)
 [![Lint & Sniffs](https://github.com/trakli/webservice/actions/workflows/lint-sniffs.yml/badge.svg?branch=main)](https://github.com/trakli/webservice/actions/workflows/lint-sniffs.yml)
 
-Money apps want your bank login, and then they want your money to be in one country, in one currency, in
-an account they can read. Get paid from abroad, keep cash, hold two currencies at once, or move money over
-mobile money, and most of your money is invisible to them. So it ends up in a spreadsheet, which holds
-anything and tells you nothing.
-
-Trakli tracks money the way it actually moves. Cash, mobile money, bank and card sit beside each other as
-wallets, in any of forty-eight currencies, converting at the rate you say applies and not one scraped from a
-market you cannot get. Your phone keeps working with no signal and settles up when it reconnects. And it
-is yours: your server, your database, no one else holding the ledger of what you earn.
+Trakli gets your money under control by showing you where it actually goes. Every wallet, balance, and
+holding you have, in as many accounts and currencies as you keep them, adds up to your real net worth,
+not just what you spent this month. And you barely type any of it: say what happened, or hand over a
+receipt, and the assistant does the logging.
 
 This is the Laravel API behind it, and what the web and mobile apps talk to.
 
 ## Features
 
-What you will not find elsewhere:
+AI native:
+
+- **An assistant that acts:** say what happened ("log $40 dinner at Mama's, split under food") and it
+  records, categorizes, transfers, and cleans up your books in bulk, proposing every change for you to
+  approve before anything is written.
+- **Reads your paperwork:** hand it receipts, statements, CSVs, or PDFs and it turns them into
+  transactions.
+- **Reports on a canvas:** ask for a report, watch it get built, then take it with you.
+- **MCP built in:** Trakli runs an MCP server, so Claude or any MCP client can read your books and record
+  transactions through tokens you mint and revoke yourself.
+
+For pro users:
 
 - **Wallets that match reality:** cash, mobile money, bank and card, side by side.
-- **Any currency, at your rate:** forty-eight of them, held at once; transfers convert at the rate you set.
+- **Any currency, at your rate:** forty-eight of them, held at once; transfers convert at the rate you
+  set, not one scraped from a market you cannot get.
 - **Offline-first:** the phone works with no signal, and changes settle cleanly when it reconnects.
-- **An assistant that can act:** ask it in plain words, and it proposes every change for you to confirm
-  before anything is written.
-- **Yours to run:** your server, your database, no bank login handed to anyone.
+- **Yours to run:** open source end to end; audit it, fork it, self-host it, with no one else holding the
+  ledger of what you earn.
 
-The rest, done properly:
+A full finance app, not a spreadsheet:
 
 - **Transactions:** Income and expenses across multiple wallets, with attachments and recurring rules.
 - **Transfers:** Move money between wallets, including cross-currency at user-set rates.
+- **Holdings:** Crypto, stocks, property, any asset; crypto priced live, everything else at the price you set.
 - **Budgets:** Scoped to categories, groups, or wallets; weekly / monthly / yearly / custom range; optional rollover; threshold and forecast alerts.
 - **Refunds:** Mark an income as refunding an earlier expense; matching budgets adjust automatically.
 - **Reminders:** Bills, budget alerts, and custom events with pause, resume, and snooze.


### PR DESCRIPTION
The readme lead framed bank sync as the villain and pitched only the multi-currency, cash-heavy case, which both undersold the app to anyone with a simple setup and attacked a feature choice that is legitimate for apps built around it. The pitch now follows the trakli.app copy: control and net worth first, the assistant doing the logging, an AI native section (assistant, paperwork extraction, canvas reports, the MCP server), and the power detail (wallets, currencies at your rate, offline-first, self-hosting) in its own list. Holdings joined the feature list since the app tracks assets, not just income and expenses.