### PR TITLE
fix(api): Accept boolean flags sent as text by form requests

### DIFF
--- a/app/Http/Controllers/API/ApiController.php
+++ b/app/Http/Controllers/API/ApiController.php
@@ -66,7 +66,7 @@ class ApiController extends BaseController
      */
     protected function validateRequest(Request $request, array $rules): array
     {
-        $validator = Validator::make($request->all(), $rules);
+        $validator = Validator::make($this->castBooleanInput($request->all(), $rules), $rules);
 
         if ($validator->fails()) {
             $errors = $validator->errors();
@@ -89,6 +89,51 @@ class ApiController extends BaseController
         }
 
         return ['isValidated' => true, 'data' => $validator->validated()];
+    }
+
+    /**
+     * Cast textual booleans for attributes the rules declare as boolean.
+     *
+     * Unrecognised values are left untouched so the boolean rule still rejects them
+     * instead of silently reading as false.
+     */
+    private function castBooleanInput(array $data, array $rules): array
+    {
+        foreach ($rules as $attribute => $rule) {
+            if (! array_key_exists($attribute, $data) || ! is_string($data[$attribute])) {
+                continue;
+            }
+
+            if (! $this->expectsBoolean($rule)) {
+                continue;
+            }
+
+            $casted = filter_var($data[$attribute], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            if (! is_null($casted)) {
+                $data[$attribute] = $casted;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Determine whether a rule set holds the boolean rule.
+     *
+     * @param  mixed  $rule
+     */
+    private function expectsBoolean($rule): bool
+    {
+        $rules = is_array($rule) ? $rule : explode('|', (string) $rule);
+
+        foreach ($rules as $singleRule) {
+            if (is_string($singleRule) && strtolower(explode(':', $singleRule)[0]) === 'boolean') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/app/Models/RecurringTransactionRule.php
+++ b/app/Models/RecurringTransactionRule.php
@@ -59,6 +59,7 @@ class RecurringTransactionRule extends Model implements HasAgentResource
     protected $casts = [
         'next_scheduled_at' => 'datetime',
         'recurrence_ends_at' => 'datetime',
+        'recurrence_interval' => 'integer',
     ];
 
     public function transaction(): BelongsTo

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -748,6 +748,58 @@ class TransactionsTest extends TestCase
         $this->assertNotNull($transaction['recurring_rules']['recurrence_ends_at']);
     }
 
+    public function test_api_user_can_create_a_recurring_transaction_from_a_form_request()
+    {
+        $response = $this->actingAs($this->user)->post('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => '100',
+            'wallet_id' => (string) $this->wallet->id,
+            'party_id' => (string) $this->party->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'is_recurring' => 'true',
+            'recurrence_period' => 'monthly',
+            'recurrence_interval' => '2',
+            'files' => [UploadedFile::fake()->image('receipt.png')],
+        ]);
+
+        $response->assertStatus(201);
+
+        $transaction = $response->json('data');
+        $this->assertEquals('monthly', $transaction['recurring_rules']['recurrence_period']);
+        $this->assertEquals(2, $transaction['recurring_rules']['recurrence_interval']);
+        $this->assertCount(1, $transaction['files']);
+    }
+
+    public function test_api_form_request_can_turn_a_recurring_transaction_off()
+    {
+        $response = $this->actingAs($this->user)->post('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => '100',
+            'wallet_id' => (string) $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'is_recurring' => 'false',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertNull($response->json('data.recurring_rules'));
+    }
+
+    public function test_api_rejects_an_is_recurring_flag_it_cannot_read()
+    {
+        $response = $this->actingAs($this->user)->post('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => '100',
+            'wallet_id' => (string) $this->wallet->id,
+            'datetime' => '2025-04-30T15:17:54.120Z',
+            'is_recurring' => 'sometimes',
+            'recurrence_period' => 'monthly',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('is_recurring');
+        $this->assertDatabaseCount('transactions', 0);
+    }
+
     public function test_api_validates_recurring_transaction_parameters()
     {
         // Test missing recurrence_period when is_recurring is true


### PR DESCRIPTION
Creating a recurring transaction from the mobile app returns 422 on `is_recurring`. Reported against multipart requests carrying a receipt, but it hits every recurring create from the app, which posts multipart whether or not a file is attached.

Two causes, both from form bodies carrying every field as text:

- `is_recurring` arrives as `"true"`, which the `boolean` rule rejects (it takes `true`/`false`, `0`/`1`, `"0"`/`"1"`, nothing else) -> boolean attributes now accept the textual spellings PHP itself recognises. Values it cannot read still 422 rather than quietly meaning false.
- `recurrence_interval` arrives as `"2"`, passes the `integer` rule, then broke scheduling once Carbon demanded a real int -> now cast on the rule.

No app change is needed for this to take effect.
