### PR TITLE
fix: Detect schema drift and add transaction exports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,5 +41,8 @@ jobs:
       - name: Run database migrations
         run: flatrun deployment exec trakli-staging app -- php artisan migrate
 
+      - name: Verify schema conformance
+        run: flatrun deployment exec trakli-staging app -- php artisan schema:verify
+
       - name: Optimize application caches
         run: flatrun deployment exec trakli-staging app -- php artisan optimize

--- a/app/Exports/CsvExporter.php
+++ b/app/Exports/CsvExporter.php
@@ -19,6 +19,11 @@ class CsvExporter implements Exporter
         return 'csv';
     }
 
+    public function maxRows(): int
+    {
+        return 20000;
+    }
+
     public function export(ExportDocument $document): string
     {
         $handle = fopen('php://temp', 'r+');

--- a/app/Exports/CsvExporter.php
+++ b/app/Exports/CsvExporter.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Exports;
+
+class CsvExporter implements Exporter
+{
+    public function key(): string
+    {
+        return 'csv';
+    }
+
+    public function mimeType(): string
+    {
+        return 'text/csv';
+    }
+
+    public function extension(): string
+    {
+        return 'csv';
+    }
+
+    public function export(ExportDocument $document): string
+    {
+        $handle = fopen('php://temp', 'r+');
+
+        fputcsv($handle, [$document->title]);
+
+        foreach ($document->meta as $label => $value) {
+            fputcsv($handle, [$label, $this->scalar($value)]);
+        }
+
+        foreach ($document->notices as $notice) {
+            fputcsv($handle, [$notice]);
+        }
+
+        foreach ($document->sections as $section) {
+            fputcsv($handle, []);
+            fputcsv($handle, [$section->heading]);
+
+            if ($section->note !== null) {
+                fputcsv($handle, [$section->note]);
+            }
+
+            foreach ($section->summary as $label => $value) {
+                fputcsv($handle, [$label, $this->scalar($value)]);
+            }
+
+            if (! $section->hasTable()) {
+                continue;
+            }
+
+            fputcsv($handle, $section->columns);
+
+            foreach ($section->rows as $row) {
+                fputcsv($handle, array_map(fn ($cell) => $this->scalar($cell), $row));
+            }
+        }
+
+        rewind($handle);
+        $contents = (string) stream_get_contents($handle);
+        fclose($handle);
+
+        // Excel reads a UTF-8 CSV as the local codepage unless it sees a BOM,
+        // which mangles currency symbols and accented category names.
+        return "\u{FEFF}" . $contents;
+    }
+
+    private function scalar(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'yes' : 'no';
+        }
+
+        return (string) ($value ?? '');
+    }
+}

--- a/app/Exports/ExportDocument.php
+++ b/app/Exports/ExportDocument.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Exports;
+
+/**
+ * A format-independent description of what an export contains. Builders produce
+ * one of these; each Exporter renders it. Adding a format means adding one
+ * Exporter, and every existing export gains it for free.
+ */
+class ExportDocument
+{
+    /**
+     * @param  array<int, ExportSection>  $sections
+     * @param  array<string, scalar|null>  $meta  Header lines (period, currency, generated at)
+     * @param  array<int, string>  $notices  Caveats that must travel with the numbers
+     */
+    public function __construct(
+        public readonly string $title,
+        public readonly array $sections,
+        public readonly array $meta = [],
+        public readonly array $notices = [],
+    ) {
+    }
+}

--- a/app/Exports/ExportSection.php
+++ b/app/Exports/ExportSection.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Exports;
+
+/**
+ * One block of an exported document: an optional set of label/value summary
+ * lines followed by an optional table. A transaction export is a single section
+ * with a table; a statement is several sections, some summary-only.
+ */
+class ExportSection
+{
+    /**
+     * @param  array<int, string>  $columns
+     * @param  iterable<int, array<int, scalar|null>>  $rows
+     * @param  array<string, scalar|null>  $summary
+     */
+    public function __construct(
+        public readonly string $heading,
+        public readonly array $columns = [],
+        public readonly iterable $rows = [],
+        public readonly array $summary = [],
+        public readonly ?string $note = null,
+    ) {
+    }
+
+    public function hasTable(): bool
+    {
+        return ! empty($this->columns);
+    }
+}

--- a/app/Exports/Exporter.php
+++ b/app/Exports/Exporter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Exports;
+
+/**
+ * Renders an ExportDocument into a concrete downloadable format. Implement one
+ * per format and register it with the ExporterManager.
+ */
+interface Exporter
+{
+    /**
+     * The format key used to select this exporter (e.g. "csv", "xlsx", "pdf").
+     */
+    public function key(): string;
+
+    public function mimeType(): string;
+
+    public function extension(): string;
+
+    public function export(ExportDocument $document): string;
+}

--- a/app/Exports/Exporter.php
+++ b/app/Exports/Exporter.php
@@ -17,5 +17,12 @@ interface Exporter
 
     public function extension(): string;
 
+    /**
+     * Largest table this format can render within one request. Measured against
+     * a 128MB limit: dompdf lays the whole document out in memory and costs
+     * about 0.4MB a row, PhpSpreadsheet about 12KB, and CSV streams.
+     */
+    public function maxRows(): int;
+
     public function export(ExportDocument $document): string;
 }

--- a/app/Exports/ExporterManager.php
+++ b/app/Exports/ExporterManager.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Exports;
+
+use InvalidArgumentException;
+
+class ExporterManager
+{
+    /** @var array<string, Exporter> */
+    private array $exporters = [];
+
+    public function __construct()
+    {
+        $this->register(new CsvExporter());
+        $this->register(new XlsxExporter());
+        $this->register(new PdfExporter());
+    }
+
+    public function register(Exporter $exporter): void
+    {
+        $this->exporters[$exporter->key()] = $exporter;
+    }
+
+    public function has(string $format): bool
+    {
+        return isset($this->exporters[$format]);
+    }
+
+    public function for(string $format): Exporter
+    {
+        if (! isset($this->exporters[$format])) {
+            throw new InvalidArgumentException("No exporter for format: {$format}");
+        }
+
+        return $this->exporters[$format];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function formats(): array
+    {
+        return array_keys($this->exporters);
+    }
+}

--- a/app/Exports/ExporterManager.php
+++ b/app/Exports/ExporterManager.php
@@ -42,4 +42,12 @@ class ExporterManager
     {
         return array_keys($this->exporters);
     }
+
+    /**
+     * @return array<string, int>
+     */
+    public function rowLimits(): array
+    {
+        return array_map(fn (Exporter $exporter) => $exporter->maxRows(), $this->exporters);
+    }
 }

--- a/app/Exports/PdfExporter.php
+++ b/app/Exports/PdfExporter.php
@@ -21,6 +21,11 @@ class PdfExporter implements Exporter
         return 'pdf';
     }
 
+    public function maxRows(): int
+    {
+        return 100;
+    }
+
     public function export(ExportDocument $document): string
     {
         $sections = array_map(

--- a/app/Exports/PdfExporter.php
+++ b/app/Exports/PdfExporter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Exports;
+
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class PdfExporter implements Exporter
+{
+    public function key(): string
+    {
+        return 'pdf';
+    }
+
+    public function mimeType(): string
+    {
+        return 'application/pdf';
+    }
+
+    public function extension(): string
+    {
+        return 'pdf';
+    }
+
+    public function export(ExportDocument $document): string
+    {
+        $sections = array_map(
+            fn (ExportSection $section) => [
+                'heading' => $section->heading,
+                'note' => $section->note,
+                'summary' => $section->summary,
+                'columns' => $section->columns,
+                // dompdf renders the whole document in one pass, so rows cannot
+                // stay lazy; a generator would be consumed before layout runs.
+                'rows' => $this->materialise($section->rows),
+            ],
+            $document->sections
+        );
+
+        return Pdf::loadView('exports.document', [
+            'title' => $document->title,
+            'meta' => $document->meta,
+            'notices' => $document->notices,
+            'sections' => $sections,
+        ])->setPaper('a4', 'landscape')->output();
+    }
+
+    /**
+     * @param  iterable<int, array<int, scalar|null>>  $rows
+     * @return array<int, array<int, scalar|null>>
+     */
+    private function materialise(iterable $rows): array
+    {
+        return is_array($rows) ? $rows : iterator_to_array($rows, false);
+    }
+}

--- a/app/Exports/ReportExportBuilder.php
+++ b/app/Exports/ReportExportBuilder.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Str;
+
+/**
+ * Turns a StatsService payload into an ExportDocument. The statement reports
+ * only what the payload actually contains, so a request scoped to one section
+ * produces a document covering that section rather than empty headings.
+ */
+class ReportExportBuilder
+{
+    /**
+     * @param  array<string, mixed>  $stats  The return value of StatsService::compute()
+     * @param  array<string, scalar|null>  $meta
+     */
+    public function build(array $stats, string $title, array $meta = []): ExportDocument
+    {
+        $currency = (string) ($stats['currency'] ?? 'USD');
+
+        $sections = array_values(array_filter([
+            $this->overview($stats, $currency),
+            $this->position($stats, $currency),
+            $this->categories($stats, $currency, 'expenses', __('Top expense categories')),
+            $this->categories($stats, $currency, 'income', __('Top income categories')),
+            $this->largestTransactions($stats, $currency),
+        ]));
+
+        return new ExportDocument(
+            title: $title,
+            sections: $sections,
+            meta: $meta + [__('Currency') => $currency],
+            notices: $this->notices($stats),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $stats
+     * @return array<int, string>
+     */
+    private function notices(array $stats): array
+    {
+        if (empty($stats['partial'])) {
+            return [];
+        }
+
+        // Without this line the reader has no way to tell that some amounts
+        // were left out of the totals rather than being zero.
+        return [__('Some amounts could not be converted and are excluded from these totals. Affected currencies: :currencies', [
+            'currencies' => implode(', ', (array) ($stats['unconverted_currencies'] ?? [])),
+        ])];
+    }
+
+    /**
+     * @param  array<string, mixed>  $stats
+     */
+    private function overview(array $stats, string $currency): ?ExportSection
+    {
+        if (! is_array($stats['overview'] ?? null)) {
+            return null;
+        }
+
+        $overview = $stats['overview'];
+
+        return new ExportSection(
+            heading: __('Overview'),
+            summary: [
+                __('Total balance') => $this->money($overview['total_balance'] ?? 0, $currency),
+                __('Total income') => $this->money($overview['total_income'] ?? 0, $currency),
+                __('Total expenses') => $this->money($overview['total_expenses'] ?? 0, $currency),
+                __('Net cash flow') => $this->money($overview['net_cash_flow'] ?? 0, $currency),
+                __('Average monthly income') => $this->money($overview['avg_monthly_income'] ?? 0, $currency),
+                __('Average monthly expenses') => $this->money($overview['avg_monthly_expenses'] ?? 0, $currency),
+                __('Savings rate') => number_format((float) ($overview['savings_rate'] ?? 0), 1) . '%',
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $stats
+     */
+    private function position(array $stats, string $currency): ?ExportSection
+    {
+        if (! is_array($stats['position'] ?? null)) {
+            return null;
+        }
+
+        $position = $stats['position'];
+
+        return new ExportSection(
+            heading: __('Financial position'),
+            summary: [
+                __('Earned income') => $this->money($position['earned_income'] ?? 0, $currency),
+                __('Discretionary spend') => $this->money($position['discretionary_spend'] ?? 0, $currency),
+                __('Cash balance') => $this->money($position['cash_balance'] ?? 0, $currency),
+                __('Holdings value') => $this->money($position['holdings_value'] ?? 0, $currency),
+                __('Total net worth') => $this->money($position['total_net_worth'] ?? 0, $currency),
+                __('Loans and debt (net)') => $this->money($position['loans_debt_net'] ?? 0, $currency),
+                __('Investment principal') => $this->money($position['investment_principal'] ?? 0, $currency),
+                __('Investment returns') => $this->money($position['investment_returns'] ?? 0, $currency),
+                __('Gifts received') => $this->money($position['gifts_received'] ?? 0, $currency),
+                __('Net worth change') => $this->money($position['net_worth_delta'] ?? 0, $currency),
+            ],
+            note: __('Borrowed money and investment purchases are balance-neutral and excluded from the net worth change.'),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $stats
+     */
+    private function categories(array $stats, string $currency, string $bucket, string $heading): ?ExportSection
+    {
+        $categories = $stats['top_categories'][$bucket] ?? null;
+
+        if (! is_array($categories) || $categories === []) {
+            return null;
+        }
+
+        $rows = [];
+        foreach ($categories as $category) {
+            $rows[] = [
+                (string) ($category['name'] ?? __('Uncategorized')),
+                $this->money($category['amount'] ?? 0, $currency),
+                (int) ($category['transaction_count'] ?? 0),
+            ];
+        }
+
+        return new ExportSection(
+            heading: $heading,
+            columns: [__('Category'), __('Amount'), __('Transactions')],
+            rows: $rows,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $stats
+     */
+    private function largestTransactions(array $stats, string $currency): ?ExportSection
+    {
+        $largest = $stats['largest_transactions'] ?? null;
+
+        if (! is_array($largest)) {
+            return null;
+        }
+
+        $rows = [];
+        foreach (['income', 'expense'] as $type) {
+            if (! is_array($largest[$type] ?? null)) {
+                continue;
+            }
+
+            $rows[] = [
+                Str::ucfirst($type),
+                (string) ($largest[$type]['date'] ?? ''),
+                (string) ($largest[$type]['description'] ?? ''),
+                (string) ($largest[$type]['category'] ?? ''),
+                $this->money($largest[$type]['amount'] ?? 0, $currency),
+            ];
+        }
+
+        if ($rows === []) {
+            return null;
+        }
+
+        return new ExportSection(
+            heading: __('Largest transactions'),
+            columns: [__('Type'), __('Date'), __('Description'), __('Category'), __('Amount')],
+            rows: $rows,
+        );
+    }
+
+    private function money(mixed $value, string $currency): string
+    {
+        return number_format((float) $value, 2) . ' ' . $currency;
+    }
+}

--- a/app/Exports/TransactionExportBuilder.php
+++ b/app/Exports/TransactionExportBuilder.php
@@ -15,12 +15,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 class TransactionExportBuilder
 {
     /**
-     * Beyond this the export stops being something a person reads and starts
-     * being a database dump; refusing is clearer than timing out mid-download.
-     */
-    public const MAX_ROWS = 20000;
-
-    /**
      * @param  array<string, scalar|null>  $meta
      */
     public function build(Builder|Relation $query, string $title, array $meta = []): ExportDocument

--- a/app/Exports/TransactionExportBuilder.php
+++ b/app/Exports/TransactionExportBuilder.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Transaction;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * Turns a filtered transaction query into an ExportDocument. Every format is
+ * rendered from the result, so the columns cannot drift between CSV, XLSX
+ * and PDF.
+ */
+class TransactionExportBuilder
+{
+    /**
+     * Beyond this the export stops being something a person reads and starts
+     * being a database dump; refusing is clearer than timing out mid-download.
+     */
+    public const MAX_ROWS = 20000;
+
+    /**
+     * @param  array<string, scalar|null>  $meta
+     */
+    public function build(Builder|Relation $query, string $title, array $meta = []): ExportDocument
+    {
+        $query = $query->with(['wallet', 'party', 'categories']);
+
+        $totals = [
+            'income' => (float) (clone $query)->where('type', 'income')->sum('amount'),
+            'expenses' => (float) (clone $query)->where('type', 'expense')->sum('amount'),
+        ];
+
+        $section = new ExportSection(
+            heading: __('Transactions'),
+            columns: [
+                __('Date'),
+                __('Type'),
+                __('Intent'),
+                __('Amount'),
+                __('Currency'),
+                __('Wallet'),
+                __('Category'),
+                __('Party'),
+                __('Description'),
+                __('Transfer leg'),
+            ],
+            rows: $this->rows($query),
+            summary: [
+                __('Total income') => $this->amount($totals['income']),
+                __('Total expenses') => $this->amount($totals['expenses']),
+                __('Net') => $this->amount($totals['income'] - $totals['expenses']),
+            ],
+            note: __('Amounts are shown in each transaction\'s own wallet currency and are not converted.'),
+        );
+
+        return new ExportDocument(
+            title: $title,
+            sections: [$section],
+            meta: $meta,
+        );
+    }
+
+    public function countRows(Builder|Relation $query): int
+    {
+        return (clone $query)->count();
+    }
+
+    /**
+     * Streamed so a large export does not hold every model in memory at once.
+     *
+     * @return iterable<int, array<int, scalar|null>>
+     */
+    private function rows(Builder|Relation $query): iterable
+    {
+        foreach ($query->lazy() as $transaction) {
+            yield $this->row($transaction);
+        }
+    }
+
+    /**
+     * @return array<int, scalar|null>
+     */
+    private function row(Transaction $transaction): array
+    {
+        return [
+            $transaction->datetime ? Carbon::parse($transaction->datetime)->toDateTimeString() : null,
+            $transaction->type,
+            str_replace('_', ' ', (string) $transaction->intent),
+            (float) $transaction->amount,
+            $transaction->wallet?->currency,
+            $transaction->wallet?->name,
+            $transaction->categories->pluck('name')->implode(', '),
+            $transaction->party?->name,
+            $transaction->description,
+            // A transfer writes an expense and an income leg. Flagging them
+            // keeps a reader from adding both into a total that double-counts.
+            $transaction->transfer_id ? __('yes') : '',
+        ];
+    }
+
+    private function amount(float $value): string
+    {
+        return number_format($value, 2, '.', '');
+    }
+}

--- a/app/Exports/XlsxExporter.php
+++ b/app/Exports/XlsxExporter.php
@@ -24,6 +24,11 @@ class XlsxExporter implements Exporter
         return 'xlsx';
     }
 
+    public function maxRows(): int
+    {
+        return 5000;
+    }
+
     public function export(ExportDocument $document): string
     {
         $spreadsheet = new Spreadsheet();

--- a/app/Exports/XlsxExporter.php
+++ b/app/Exports/XlsxExporter.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Exports;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use RuntimeException;
+
+class XlsxExporter implements Exporter
+{
+    public function key(): string
+    {
+        return 'xlsx';
+    }
+
+    public function mimeType(): string
+    {
+        return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+
+    public function extension(): string
+    {
+        return 'xlsx';
+    }
+
+    public function export(ExportDocument $document): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->removeSheetByIndex(0);
+
+        $sections = $document->sections;
+        if (empty($sections)) {
+            $sections = [new ExportSection(__('Summary'))];
+        }
+
+        foreach (array_values($sections) as $index => $section) {
+            $sheet = $spreadsheet->createSheet();
+            $sheet->setTitle($this->sheetTitle($section->heading, $index));
+
+            $rows = $index === 0
+                ? $this->headerRows($document)
+                : [];
+
+            $rows[] = [$section->heading];
+
+            if ($section->note !== null) {
+                $rows[] = [$section->note];
+            }
+
+            foreach ($section->summary as $label => $value) {
+                $rows[] = [$label, $value];
+            }
+
+            if ($section->hasTable()) {
+                $rows[] = [];
+                $rows[] = $section->columns;
+
+                foreach ($section->rows as $row) {
+                    $rows[] = array_values($row);
+                }
+            }
+
+            $sheet->fromArray($rows, null, 'A1', true);
+            $this->autoSize($sheet, $rows);
+        }
+
+        $spreadsheet->setActiveSheetIndex(0);
+
+        return $this->render($spreadsheet);
+    }
+
+    /**
+     * @return array<int, array<int, scalar|null>>
+     */
+    private function headerRows(ExportDocument $document): array
+    {
+        $rows = [[$document->title]];
+
+        foreach ($document->meta as $label => $value) {
+            $rows[] = [$label, $value];
+        }
+
+        foreach ($document->notices as $notice) {
+            $rows[] = [$notice];
+        }
+
+        $rows[] = [];
+
+        return $rows;
+    }
+
+    /**
+     * Excel rejects sheet names over 31 characters or containing []:*?/\, and
+     * silently breaks on duplicates, so every title is normalised and suffixed.
+     */
+    private function sheetTitle(string $heading, int $index): string
+    {
+        $title = preg_replace('/[\[\]:*?\/\\\\]/', ' ', $heading) ?? 'Sheet';
+        $title = trim(preg_replace('/\s+/', ' ', $title) ?? '');
+
+        if ($title === '') {
+            $title = 'Sheet';
+        }
+
+        $suffix = ' ' . ($index + 1);
+
+        return mb_substr($title, 0, 31 - mb_strlen($suffix)) . $suffix;
+    }
+
+    /**
+     * @param  array<int, array<int, scalar|null>>  $rows
+     */
+    private function autoSize(Worksheet $sheet, array $rows): void
+    {
+        $widest = 0;
+        foreach ($rows as $row) {
+            $widest = max($widest, count($row));
+        }
+
+        for ($column = 1; $column <= $widest; $column++) {
+            $sheet->getColumnDimensionByColumn($column)->setAutoSize(true);
+        }
+    }
+
+    private function render(Spreadsheet $spreadsheet): string
+    {
+        // The xlsx writer builds a zip archive, which needs a real path rather
+        // than an in-memory stream.
+        $path = tempnam(sys_get_temp_dir(), 'trakli-export-');
+
+        if ($path === false) {
+            throw new RuntimeException('Unable to allocate a temporary file for the export.');
+        }
+
+        try {
+            (new Xlsx($spreadsheet))->save($path);
+
+            return (string) file_get_contents($path);
+        } finally {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/API/v1/ExportController.php
+++ b/app/Http/Controllers/API/v1/ExportController.php
@@ -105,14 +105,27 @@ class ExportController extends ApiController
 
         $this->applyTransactionFilters($query, $request);
 
+        $exporter = $this->exporters->for($format);
+
         $count = $this->transactionBuilder->countRows($query);
-        if ($count > TransactionExportBuilder::MAX_ROWS) {
+        if ($count > $exporter->maxRows()) {
             return $this->failure(
-                __('This export covers :count transactions, which is over the limit of :max. Narrow the date range or wallets and try again.', [
+                __(
+                    'This export covers :count transactions, over the limit of :max for :format files. '
+                        . 'Narrow the date range or wallets, or pick a format that holds more.',
+                    [
+                        'count' => $count,
+                        'max' => $exporter->maxRows(),
+                        'format' => strtoupper($format),
+                    ]
+                ),
+                422,
+                [
                     'count' => $count,
-                    'max' => TransactionExportBuilder::MAX_ROWS,
-                ]),
-                422
+                    'max_rows' => $exporter->maxRows(),
+                    'format' => $format,
+                    'format_limits' => $this->exporters->rowLimits(),
+                ]
             );
         }
 

--- a/app/Http/Controllers/API/v1/ExportController.php
+++ b/app/Http/Controllers/API/v1/ExportController.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Http\Controllers\API\v1;
+
+use App\Exports\ExportDocument;
+use App\Exports\ExporterManager;
+use App\Exports\ReportExportBuilder;
+use App\Exports\TransactionExportBuilder;
+use App\Http\Controllers\API\ApiController;
+use App\Http\Traits\FiltersTransactions;
+use App\Http\Traits\ResolvesStatsQuery;
+use App\Models\User;
+use App\Services\StatsService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use OpenApi\Attributes as OA;
+
+#[OA\Tag(name: 'Exports', description: 'Downloadable transaction lists and statements')]
+class ExportController extends ApiController
+{
+    use FiltersTransactions;
+    use ResolvesStatsQuery;
+
+    public function __construct(
+        private ExporterManager $exporters,
+        private TransactionExportBuilder $transactionBuilder,
+        private ReportExportBuilder $reportBuilder,
+        private StatsService $statsService,
+    ) {
+    }
+
+    #[OA\Get(
+        path: '/transactions/export',
+        summary: 'Download the filtered transaction list as a file',
+        description: 'Accepts the same filters as the transaction list endpoint so the download matches what the client is showing.',
+        tags: ['Exports'],
+        parameters: [
+            new OA\Parameter(
+                name: 'format',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', default: 'csv', enum: ['csv', 'xlsx', 'pdf'])
+            ),
+            new OA\Parameter(
+                name: 'type',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', enum: ['income', 'expense'])
+            ),
+            new OA\Parameter(name: 'date_from', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(name: 'date_to', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(
+                name: 'wallet_ids',
+                description: 'Comma-separated wallet ids',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'category_ids',
+                description: 'Comma-separated category ids',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'intent',
+                description: 'Comma-separated transaction intents',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(name: 'exclude_transfers', in: 'query', required: false, schema: new OA\Schema(type: 'boolean')),
+            new OA\Parameter(name: 'search', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'The export as a file download'),
+            new OA\Response(response: 422, description: 'Unsupported format, invalid filter, or too many rows'),
+        ]
+    )]
+    public function transactions(Request $request): Response|JsonResponse
+    {
+        $format = (string) $request->query('format', 'csv');
+        if (! $this->exporters->has($format)) {
+            return $this->unsupportedFormat();
+        }
+
+        $type = $request->query('type');
+        if (! empty($type) && ! in_array($type, ['income', 'expense'], true)) {
+            return $this->failure(__('Invalid transaction type'), 422);
+        }
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $query = $user->transactions()
+            ->orderBy('datetime', 'desc')
+            ->orderBy('created_at', 'desc');
+
+        if (! empty($type)) {
+            $query->where('type', $type);
+        }
+
+        $this->applyTransactionFilters($query, $request);
+
+        $count = $this->transactionBuilder->countRows($query);
+        if ($count > TransactionExportBuilder::MAX_ROWS) {
+            return $this->failure(
+                __('This export covers :count transactions, which is over the limit of :max. Narrow the date range or wallets and try again.', [
+                    'count' => $count,
+                    'max' => TransactionExportBuilder::MAX_ROWS,
+                ]),
+                422
+            );
+        }
+
+        $document = $this->transactionBuilder->build($query, __('Transactions'), [
+            __('Generated') => now()->toDayDateTimeString(),
+            __('Transactions') => $count,
+        ]);
+
+        return $this->download($document, $format, 'transactions');
+    }
+
+    #[OA\Get(
+        path: '/reports/export',
+        summary: 'Download a financial statement as a file',
+        description: 'Renders the same analytics as the stats endpoint into a formatted statement.',
+        tags: ['Exports'],
+        parameters: [
+            new OA\Parameter(
+                name: 'format',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', default: 'pdf', enum: ['csv', 'xlsx', 'pdf'])
+            ),
+            new OA\Parameter(name: 'start_date', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(name: 'end_date', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(
+                name: 'preset',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', enum: ['all_time', 'current_week', 'current_month', 'last_3_months'])
+            ),
+            new OA\Parameter(
+                name: 'wallet_ids',
+                description: 'Comma-separated wallet ids',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string')
+            ),
+            new OA\Parameter(
+                name: 'period',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'string', default: 'month', enum: ['day', 'week', 'month', 'year'])
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'The statement as a file download'),
+            new OA\Response(response: 422, description: 'Unsupported format or invalid wallet ids'),
+        ]
+    )]
+    public function report(Request $request): Response|JsonResponse
+    {
+        $format = (string) $request->query('format', 'pdf');
+        if (! $this->exporters->has($format)) {
+            return $this->unsupportedFormat();
+        }
+
+        $user = $request->user();
+
+        [$startDate, $endDate] = $this->resolveDateRange($request);
+
+        $walletIds = $this->resolveWalletIds($request, $user);
+        if ($walletIds instanceof JsonResponse) {
+            return $walletIds;
+        }
+
+        $stats = $this->statsService->compute(
+            $user,
+            $startDate,
+            $endDate,
+            $walletIds,
+            (string) $request->input('period', 'month'),
+            $user->getConfigValue('default-currency') ?? 'USD'
+        );
+
+        $document = $this->reportBuilder->build($stats, __('Financial statement'), [
+            __('Period') => $startDate->toDateString() . ' to ' . $endDate->toDateString(),
+            __('Generated') => now()->toDayDateTimeString(),
+        ]);
+
+        return $this->download($document, $format, 'statement');
+    }
+
+    private function download(ExportDocument $document, string $format, string $basename): Response
+    {
+        $exporter = $this->exporters->for($format);
+        $filename = Str::slug($basename . ' ' . now()->toDateString()) . '.' . $exporter->extension();
+
+        return response($exporter->export($document), Response::HTTP_OK, [
+            'Content-Type' => $exporter->mimeType(),
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+        ]);
+    }
+
+    private function unsupportedFormat(): JsonResponse
+    {
+        return $this->failure(__('Unsupported export format.'), Response::HTTP_UNPROCESSABLE_ENTITY, [
+            'supported_formats' => $this->exporters->formats(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/API/v1/StatsController.php
+++ b/app/Http/Controllers/API/v1/StatsController.php
@@ -3,9 +3,8 @@
 namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
-use App\Models\Wallet;
+use App\Http\Traits\ResolvesStatsQuery;
 use App\Services\StatsService;
-use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -14,6 +13,8 @@ use OpenApi\Attributes as OA;
 #[OA\Tag(name: 'Statistics', description: 'Financial statistics and analytics')]
 class StatsController extends ApiController
 {
+    use ResolvesStatsQuery;
+
     public function __construct(
         protected StatsService $statsService
     ) {
@@ -147,58 +148,5 @@ class StatsController extends ApiController
         );
 
         return $this->success($data);
-    }
-
-    private function resolveDateRange(Request $request): array
-    {
-        $endDate = Carbon::now()->endOfDay();
-        $startDate = Carbon::now()->subDays(30)->startOfDay();
-
-        if ($request->has('preset')) {
-            $endDate = Carbon::now()->endOfDay();
-
-            $startDate = match ($request->input('preset')) {
-                'all_time' => Carbon::parse('2000-01-01')->startOfDay(),
-                'current_week' => Carbon::now()->startOfWeek()->startOfDay(),
-                'current_month' => Carbon::now()->startOfMonth()->startOfDay(),
-                'last_3_months' => Carbon::now()->subMonths(3)->startOfDay(),
-                default => Carbon::now()->subDays(30)->startOfDay(),
-            };
-        } else {
-            if ($request->has('start_date')) {
-                $startDate = Carbon::parse($request->input('start_date'))->startOfDay();
-            }
-            if ($request->has('end_date')) {
-                $endDate = Carbon::parse($request->input('end_date'))->endOfDay();
-            }
-        }
-
-        return [$startDate, $endDate];
-    }
-
-    /**
-     * @return array|JsonResponse
-     */
-    private function resolveWalletIds(Request $request, $user): array|JsonResponse
-    {
-        if (! $request->has('wallet_ids')) {
-            return [];
-        }
-
-        $walletIds = array_filter(array_map('intval', explode(',', $request->input('wallet_ids'))));
-
-        $validWalletIds = Wallet::where('user_id', $user->id)
-            ->whereIn('id', $walletIds)
-            ->pluck('id')
-            ->toArray();
-
-        $invalidWalletIds = array_diff($walletIds, $validWalletIds);
-        if (! empty($invalidWalletIds)) {
-            return $this->failure(__('One or more wallet IDs are invalid or do not belong to the user.'), 422, [
-                'invalid_wallet_ids' => array_values($invalidWalletIds),
-            ]);
-        }
-
-        return $walletIds;
     }
 }

--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API\v1;
 use App\Enums\TransactionIntent;
 use App\Http\Controllers\API\ApiController;
 use App\Http\Traits\ApiQueryable;
+use App\Http\Traits\FiltersTransactions;
 use App\Jobs\RecurrentTransactionJob;
 use App\Models\RecurringTransactionRule;
 use App\Models\Transaction;
@@ -25,6 +26,7 @@ use Throwable;
 class TransactionController extends ApiController
 {
     use ApiQueryable;
+    use FiltersTransactions;
 
     public function __construct(
         private RecurringTransactionService $recurringTransactionService,
@@ -840,89 +842,5 @@ class TransactionController extends ApiController
         $transaction->delete();
 
         return $this->success(['message' => __('Transaction deleted successfully')]);
-    }
-
-    /**
-     * Apply optional filtering query parameters (date range, wallets,
-     * categories, search) to the given transaction query.
-     */
-    private function applyTransactionFilters($query, Request $request): void
-    {
-        if ($request->filled('date_from')) {
-            $query->whereDate('datetime', '>=', $request->query('date_from'));
-        }
-
-        if ($request->filled('date_to')) {
-            $query->whereDate('datetime', '<=', $request->query('date_to'));
-        }
-
-        $walletIds = $this->listParam($request, 'wallet_ids');
-        if (! empty($walletIds)) {
-            $query->whereIn('wallet_id', $walletIds);
-        }
-
-        $categoryIds = $this->listParam($request, 'category_ids');
-        if (! empty($categoryIds)) {
-            $query->whereHas('categories', function ($q) use ($categoryIds) {
-                $q->whereIn('categories.id', $categoryIds);
-            });
-        }
-
-        $this->applyIntentFilters($query, $request);
-
-        if ($request->filled('search')) {
-            $this->applySearchFilter($query, (string) $request->query('search'));
-        }
-    }
-
-    private function applyIntentFilters($query, Request $request): void
-    {
-        $intents = array_values(array_intersect(
-            $this->listParam($request, 'intent'),
-            TransactionIntent::values()
-        ));
-        if (! empty($intents)) {
-            $query->whereIn('intent', $intents);
-        }
-
-        if ($request->boolean('exclude_transfers')) {
-            $query->nonTransfer();
-        }
-    }
-
-    /**
-     * Parse a list query parameter that may arrive either as an array
-     * (key[]=a&key[]=b) or a comma-separated string (key=a,b), returning a
-     * trimmed list with empty entries removed.
-     */
-    private function listParam(Request $request, string $key): array
-    {
-        $value = $request->query($key);
-        if ($value === null || $value === '') {
-            return [];
-        }
-
-        $items = is_array($value) ? $value : explode(',', (string) $value);
-
-        return array_values(array_filter(
-            array_map('trim', $items),
-            fn ($item) => $item !== ''
-        ));
-    }
-
-    /**
-     * Apply a free-text search filter that matches against the description
-     * and, when the query contains a number, also the exact amount.
-     */
-    private function applySearchFilter($query, string $search): void
-    {
-        $query->where(function ($q) use ($search) {
-            $q->where('description', 'LIKE', '%' . $search . '%');
-
-            $numeric = preg_replace('/[^0-9.]/', '', $search);
-            if ($numeric !== '' && is_numeric($numeric)) {
-                $q->orWhere('amount', $numeric);
-            }
-        });
     }
 }

--- a/app/Http/Traits/FiltersTransactions.php
+++ b/app/Http/Traits/FiltersTransactions.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Traits;
+
+use App\Enums\TransactionIntent;
+use Illuminate\Http\Request;
+
+/**
+ * Shared query filtering for transaction listings. Listing and exporting must
+ * read the same parameters the same way, or a downloaded statement stops
+ * matching the rows the user is looking at.
+ */
+trait FiltersTransactions
+{
+    /**
+     * Apply optional filtering query parameters (date range, wallets,
+     * categories, search) to the given transaction query.
+     */
+    protected function applyTransactionFilters($query, Request $request): void
+    {
+        if ($request->filled('date_from')) {
+            $query->whereDate('datetime', '>=', $request->query('date_from'));
+        }
+
+        if ($request->filled('date_to')) {
+            $query->whereDate('datetime', '<=', $request->query('date_to'));
+        }
+
+        $walletIds = $this->listParam($request, 'wallet_ids');
+        if (! empty($walletIds)) {
+            $query->whereIn('wallet_id', $walletIds);
+        }
+
+        $categoryIds = $this->listParam($request, 'category_ids');
+        if (! empty($categoryIds)) {
+            $query->whereHas('categories', function ($q) use ($categoryIds) {
+                $q->whereIn('categories.id', $categoryIds);
+            });
+        }
+
+        $this->applyIntentFilters($query, $request);
+
+        if ($request->filled('search')) {
+            $this->applySearchFilter($query, (string) $request->query('search'));
+        }
+    }
+
+    protected function applyIntentFilters($query, Request $request): void
+    {
+        $intents = array_values(array_intersect(
+            $this->listParam($request, 'intent'),
+            TransactionIntent::values()
+        ));
+        if (! empty($intents)) {
+            $query->whereIn('intent', $intents);
+        }
+
+        if ($request->boolean('exclude_transfers')) {
+            $query->nonTransfer();
+        }
+    }
+
+    /**
+     * Parse a list query parameter that may arrive either as an array
+     * (key[]=a&key[]=b) or a comma-separated string (key=a,b), returning a
+     * trimmed list with empty entries removed.
+     */
+    protected function listParam(Request $request, string $key): array
+    {
+        $value = $request->query($key);
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        $items = is_array($value) ? $value : explode(',', (string) $value);
+
+        return array_values(array_filter(
+            array_map('trim', $items),
+            fn ($item) => $item !== ''
+        ));
+    }
+
+    /**
+     * Apply a free-text search filter that matches against the description
+     * and, when the query contains a number, also the exact amount.
+     */
+    protected function applySearchFilter($query, string $search): void
+    {
+        $query->where(function ($q) use ($search) {
+            $q->where('description', 'LIKE', '%' . $search . '%');
+
+            $numeric = preg_replace('/[^0-9.]/', '', $search);
+            if ($numeric !== '' && is_numeric($numeric)) {
+                $q->orWhere('amount', $numeric);
+            }
+        });
+    }
+}

--- a/app/Http/Traits/ResolvesStatsQuery.php
+++ b/app/Http/Traits/ResolvesStatsQuery.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Traits;
+
+use App\Models\Wallet;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Shared parameter handling for anything driven by StatsService, so a statement
+ * covers exactly the period and wallets the equivalent stats call would.
+ */
+trait ResolvesStatsQuery
+{
+    /**
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    protected function resolveDateRange(Request $request): array
+    {
+        $endDate = Carbon::now()->endOfDay();
+        $startDate = Carbon::now()->subDays(30)->startOfDay();
+
+        if ($request->has('preset')) {
+            $endDate = Carbon::now()->endOfDay();
+
+            $startDate = match ($request->input('preset')) {
+                'all_time' => Carbon::parse('2000-01-01')->startOfDay(),
+                'current_week' => Carbon::now()->startOfWeek()->startOfDay(),
+                'current_month' => Carbon::now()->startOfMonth()->startOfDay(),
+                'last_3_months' => Carbon::now()->subMonths(3)->startOfDay(),
+                default => Carbon::now()->subDays(30)->startOfDay(),
+            };
+        } else {
+            if ($request->has('start_date')) {
+                $startDate = Carbon::parse($request->input('start_date'))->startOfDay();
+            }
+            if ($request->has('end_date')) {
+                $endDate = Carbon::parse($request->input('end_date'))->endOfDay();
+            }
+        }
+
+        return [$startDate, $endDate];
+    }
+
+    /**
+     * @return array|JsonResponse
+     */
+    protected function resolveWalletIds(Request $request, $user): array|JsonResponse
+    {
+        if (! $request->has('wallet_ids')) {
+            return [];
+        }
+
+        $walletIds = array_filter(array_map('intval', explode(',', $request->input('wallet_ids'))));
+
+        $validWalletIds = Wallet::where('user_id', $user->id)
+            ->whereIn('id', $walletIds)
+            ->pluck('id')
+            ->toArray();
+
+        $invalidWalletIds = array_diff($walletIds, $validWalletIds);
+        if (! empty($invalidWalletIds)) {
+            return $this->failure(__('One or more wallet IDs are invalid or do not belong to the user.'), 422, [
+                'invalid_wallet_ids' => array_values($invalidWalletIds),
+            ]);
+        }
+
+        return $walletIds;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "license": "proprietary",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "cviebrock/eloquent-sluggable": "^11.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^11.45.1",
@@ -18,6 +19,7 @@
         "laravel/reverb": "^1.10",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
+        "phpoffice/phpspreadsheet": "^5.9",
         "prism-php/prism": "^0.100.1",
         "rlanvin/php-rrule": "^2.6",
         "smartpings/php-sdk": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41fe754d80469450cfb18548eaeb9c55",
+    "content-hash": "49f959d2e2b0512279fe0d62fbd85c96",
     "packages": [
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9.16|^10|^11.0",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T08:51:10+00:00"
+        },
         {
             "name": "beste/clock",
             "version": "3.0.0",
@@ -542,6 +619,85 @@
             "time": "2025-11-27T18:57:36+00:00"
         },
         {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
             "name": "cuyz/valinor",
             "version": "2.3.2",
             "source": {
@@ -932,6 +1088,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/6d4b4eb8500f7a786da8868ba463a71b725a4005",
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.6"
+            },
+            "time": "2026-07-20T12:29:38+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -4064,6 +4375,258 @@
             "time": "2026-03-08T20:05:35+00:00"
         },
         {
+            "name": "maennchen/zipstream-php",
+            "version": "3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "php-64bit": "^8.2"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.7",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.16",
+                "guzzlehttp/guzzle": "^7.5",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^11.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "^2.4",
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-27T12:07:53+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
+                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.2"
+            },
+            "time": "2022-12-06T16:21:08+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/728434227fe21be27ff6d86621a1b13107a2562c",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@demon-angel.eu"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
+                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
+            },
+            "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
+            },
+            "time": "2026-06-23T18:43:15+00:00"
+        },
+        {
             "name": "moneyphp/money",
             "version": "v4.9.0",
             "source": {
@@ -4848,6 +5411,115 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "5.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1||^2||^3",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-filter": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "maennchen/zipstream-php": "^2.1 || ^3.0",
+                "markbaker/complex": "^3.0",
+                "markbaker/matrix": "^3.0",
+                "php": "^8.2",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
+                "dompdf/dompdf": "^2.0 || ^3.0",
+                "ext-intl": "*",
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "mitoteam/jpgraph": "^10.5",
+                "mpdf/mpdf": "^8.1.1",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.1 || ^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^10.5 || ^11.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "ext-intl": "PHP Internationalization Functions, required for NumberFormat Wizard and StringHelper::setLocale()",
+                "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                },
+                {
+                    "name": "Owen Leibman"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.9.0"
+            },
+            "time": "2026-07-12T19:17:39+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -6659,6 +7331,86 @@
                 "source": "https://github.com/rlanvin/php-rrule/tree/v2.6.0"
             },
             "time": "2025-04-25T07:40:09+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.33 || 2.2.2",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.16",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.11",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.4.6",
+                "rector/type-perfect": "1.0.0 || 2.1.3",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.3"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.4.0"
+            },
+            "time": "2026-06-18T15:10:53+00:00"
         },
         {
             "name": "smartpings/php-sdk",
@@ -9557,6 +10309,149 @@
             "time": "2026-03-24T13:12:05+00:00"
         },
         {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.4.0",
             "source": {
@@ -10723,85 +11618,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "composer/pcre",
-            "version": "3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<1.11.10"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
-            },
-            "type": "library",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Pcre\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
-            "keywords": [
-                "PCRE",
-                "preg",
-                "regex",
-                "regular expression"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-11-12T16:29:46+00:00"
-        },
         {
             "name": "composer/xdebug-handler",
             "version": "3.0.5",

--- a/config/schema.php
+++ b/config/schema.php
@@ -18,6 +18,11 @@
  *   timestamp, json, enum (with `values`)
  *
  * Index specs: ['columns' => [...], 'name' => 'optional', 'unique' => bool]
+ *
+ * Any migration that ALTERS an existing table must also declare what it adds
+ * here. A create migration either ran or the table is absent (which `verify`
+ * reports on its own), but an ALTER that never reached an environment leaves a
+ * table that looks fine and fails on write. SchemaConformanceTest enforces this.
  */
 
 return [
@@ -29,6 +34,29 @@ return [
     'enforce' => env('SCHEMA_CONFORMANCE_ENFORCE', true),
 
     'tables' => [
+        'transactions' => [
+            'columns' => [
+                'intent' => ['type' => 'string', 'default' => 'regular'],
+                'metadata' => ['type' => 'json', 'nullable' => true],
+            ],
+            'indexes' => [
+                ['columns' => ['intent']],
+                ['columns' => ['datetime']],
+            ],
+        ],
+
+        'files' => [
+            'columns' => [
+                'metadata' => ['type' => 'json', 'nullable' => true],
+            ],
+        ],
+
+        'chat_messages' => [
+            'columns' => [
+                'progress' => ['type' => 'json', 'nullable' => true],
+            ],
+        ],
+
         'reminders' => [
             'columns' => [
                 'source' => ['type' => 'string', 'nullable' => true],

--- a/database/migrations/2026_08_05_000001_add_remindable_columns_to_reminders_table.php
+++ b/database/migrations/2026_08_05_000001_add_remindable_columns_to_reminders_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        // These columns previously existed only through schema:conform, so any
+        // database that has already been conformed will skip the additions here.
+        Schema::table('reminders', function (Blueprint $table) {
+            if (! Schema::hasColumn('reminders', 'source')) {
+                $table->string('source')->nullable()->after('type');
+            }
+
+            if (! Schema::hasColumn('reminders', 'remindable_type')) {
+                $table->string('remindable_type')->nullable()->after('source');
+            }
+
+            if (! Schema::hasColumn('reminders', 'remindable_id')) {
+                $table->unsignedBigInteger('remindable_id')->nullable()->after('remindable_type');
+            }
+        });
+
+        if (! Schema::hasIndex('reminders', 'reminders_remindable_index')) {
+            Schema::table('reminders', function (Blueprint $table) {
+                $table->index(['remindable_type', 'remindable_id'], 'reminders_remindable_index');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasIndex('reminders', 'reminders_remindable_index')) {
+            Schema::table('reminders', function (Blueprint $table) {
+                $table->dropIndex('reminders_remindable_index');
+            });
+        }
+
+        Schema::table('reminders', function (Blueprint $table) {
+            $table->dropColumn(['source', 'remindable_type', 'remindable_id']);
+        });
+    }
+};

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -1792,6 +1792,203 @@
                 }
             }
         },
+        "/transactions/export": {
+            "get": {
+                "tags": [
+                    "Exports"
+                ],
+                "summary": "Download the filtered transaction list as a file",
+                "description": "Accepts the same filters as the transaction list endpoint so the download matches what the client is showing.",
+                "operationId": "ce9e29ced3553313e76747c07d38288b",
+                "parameters": [
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "csv",
+                            "enum": [
+                                "csv",
+                                "xlsx",
+                                "pdf"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "income",
+                                "expense"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "date_from",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "date_to",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "wallet_ids",
+                        "in": "query",
+                        "description": "Comma-separated wallet ids",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "category_ids",
+                        "in": "query",
+                        "description": "Comma-separated category ids",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "intent",
+                        "in": "query",
+                        "description": "Comma-separated transaction intents",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "exclude_transfers",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The export as a file download"
+                    },
+                    "422": {
+                        "description": "Unsupported format, invalid filter, or too many rows"
+                    }
+                }
+            }
+        },
+        "/reports/export": {
+            "get": {
+                "tags": [
+                    "Exports"
+                ],
+                "summary": "Download a financial statement as a file",
+                "description": "Renders the same analytics as the stats endpoint into a formatted statement.",
+                "operationId": "f46810a8f80612df8304c4baf47ea4d8",
+                "parameters": [
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "pdf",
+                            "enum": [
+                                "csv",
+                                "xlsx",
+                                "pdf"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "preset",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "all_time",
+                                "current_week",
+                                "current_month",
+                                "last_3_months"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "wallet_ids",
+                        "in": "query",
+                        "description": "Comma-separated wallet ids",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "period",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "month",
+                            "enum": [
+                                "day",
+                                "week",
+                                "month",
+                                "year"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The statement as a file download"
+                    },
+                    "422": {
+                        "description": "Unsupported format or invalid wallet ids"
+                    }
+                }
+            }
+        },
         "/files/{id}": {
             "get": {
                 "tags": [
@@ -6629,6 +6826,10 @@
         {
             "name": "Currency",
             "description": "Exchange rates and asset prices"
+        },
+        {
+            "name": "Exports",
+            "description": "Downloadable transaction lists and statements"
         },
         {
             "name": "Files",

--- a/resources/views/exports/document.blade.php
+++ b/resources/views/exports/document.blade.php
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $title }}</title>
+    <style>
+        @page { margin: 18mm 14mm; }
+        body { font-family: DejaVu Sans, sans-serif; font-size: 9pt; color: #1a1a1a; }
+        h1 { font-size: 16pt; margin: 0 0 4mm; }
+        h2 { font-size: 11pt; margin: 6mm 0 2mm; padding-bottom: 1mm; border-bottom: 1px solid #d4d4d4; }
+        .meta { color: #555; font-size: 8pt; margin-bottom: 2mm; }
+        .meta span { margin-right: 6mm; }
+        .notice { background: #fdf3e2; border-left: 3px solid #d9a441; padding: 2mm 3mm; margin-bottom: 3mm; font-size: 8pt; }
+        .note { color: #555; font-size: 8pt; margin-bottom: 2mm; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { text-align: left; padding: 1.4mm 2mm; border-bottom: 1px solid #e6e6e6; }
+        th { background: #f4f4f4; font-size: 8pt; text-transform: uppercase; letter-spacing: 0.4pt; }
+        tr { page-break-inside: avoid; }
+        .summary td { border-bottom: none; padding: 0.8mm 0; }
+        .summary .label { color: #555; width: 45%; }
+        .summary .value { text-align: right; font-weight: bold; }
+        .empty { color: #777; font-style: italic; }
+    </style>
+</head>
+<body>
+<h1>{{ $title }}</h1>
+
+@if (! empty($meta))
+    <div class="meta">
+        @foreach ($meta as $label => $value)
+            <span>{{ $label }}: {{ $value }}</span>
+        @endforeach
+    </div>
+@endif
+
+@foreach ($notices as $notice)
+    <div class="notice">{{ $notice }}</div>
+@endforeach
+
+@foreach ($sections as $section)
+    <h2>{{ $section['heading'] }}</h2>
+
+    @if ($section['note'])
+        <div class="note">{{ $section['note'] }}</div>
+    @endif
+
+    @if (! empty($section['summary']))
+        <table class="summary">
+            @foreach ($section['summary'] as $label => $value)
+                <tr>
+                    <td class="label">{{ $label }}</td>
+                    <td class="value">{{ $value }}</td>
+                </tr>
+            @endforeach
+        </table>
+    @endif
+
+    @if (! empty($section['columns']))
+        <table>
+            <thead>
+            <tr>
+                @foreach ($section['columns'] as $column)
+                    <th>{{ $column }}</th>
+                @endforeach
+            </tr>
+            </thead>
+            <tbody>
+            @forelse ($section['rows'] as $row)
+                <tr>
+                    @foreach ($row as $cell)
+                        <td>{{ $cell }}</td>
+                    @endforeach
+                </tr>
+            @empty
+                <tr>
+                    <td class="empty" colspan="{{ count($section['columns']) }}">{{ __('Nothing to show for this selection.') }}</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    @endif
+@endforeach
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\API\v1\McpTokenController;
 use App\Http\Controllers\API\v1\BudgetController;
 use App\Http\Controllers\API\v1\BudgetPeriodStateController;
 use App\Http\Controllers\API\v1\CategoryController;
+use App\Http\Controllers\API\v1\ExportController;
 use App\Http\Controllers\API\v1\FileController;
 use App\Http\Controllers\API\v1\GroupController;
 use App\Http\Controllers\API\v1\ImportController;
@@ -59,6 +60,9 @@ Route::group(['prefix' => 'v1', 'middleware' => ['auth:sanctum']], function () {
         Route::get('stats', [StatsController::class, 'index']);
     });
     Route::get('integrations', [IntegrationController::class, 'index']);
+    // Ahead of the resource route so "export" is not read as a transaction id.
+    Route::get('transactions/export', [ExportController::class, 'transactions']);
+    Route::get('reports/export', [ExportController::class, 'report']);
     Route::apiResource('transactions', TransactionController::class);
     Route::post('/transactions/{id}/files', [TransactionController::class, 'uploadFiles']);
     Route::delete('/transactions/{id}/files/{file_id}', [TransactionController::class, 'deleteFiles']);

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Exports\ExporterManager;
+use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -138,6 +140,36 @@ class ExportTest extends TestCase
         $response->assertStatus(422);
         $response->assertJsonPath('success', false);
         $this->assertContains('csv', $response->json('errors.supported_formats'));
+    }
+
+    /**
+     * dompdf lays the whole document out in memory, so it holds far less than
+     * the other formats. The limit has to be enforced per format, or a large
+     * selection exhausts the worker instead of returning an error.
+     */
+    public function test_the_row_limit_is_enforced_per_format(): void
+    {
+        $pdfLimit = app(ExporterManager::class)->for('pdf')->maxRows();
+
+        // Bulk setup only; the export itself still goes over HTTP.
+        Transaction::factory()->count($pdfLimit + 1)->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $this->wallet->id,
+            'datetime' => now(),
+        ]);
+
+        $pdf = $this->actingAs($this->user)->getJson('/api/v1/transactions/export?format=pdf');
+        $pdf->assertStatus(422);
+        $pdf->assertJsonPath('errors.format', 'pdf');
+        $pdf->assertJsonPath('errors.max_rows', $pdfLimit);
+        $this->assertGreaterThan(
+            $pdfLimit,
+            $pdf->json('errors.format_limits.csv'),
+            'the error should point at a format that holds more'
+        );
+
+        $csv = $this->actingAs($this->user)->get('/api/v1/transactions/export?format=csv');
+        $csv->assertStatus(200);
     }
 
     public function test_report_export_renders_a_statement(): void

--- a/tests/Feature/ExportTest.php
+++ b/tests/Feature/ExportTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private $wallet;
+
+    private $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+
+        $this->wallet = $this->user->wallets()->create([
+            'name' => 'Everyday',
+            'balance' => 0,
+            'currency' => 'USD',
+        ]);
+
+        $this->category = $this->user->categories()->create([
+            'name' => 'Groceries',
+            'type' => 'expense',
+        ]);
+    }
+
+    private function createTransaction(array $overrides = []): array
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', array_merge([
+            'type' => 'expense',
+            'amount' => 100,
+            'description' => 'Weekly shop',
+            'wallet_id' => $this->wallet->id,
+            'categories' => [$this->category->id],
+            'datetime' => '2026-03-15T10:00:00.000Z',
+        ], $overrides));
+
+        $response->assertStatus(201);
+
+        return $response->json('data');
+    }
+
+    public function test_transactions_export_defaults_to_csv(): void
+    {
+        $this->createTransaction();
+
+        $response = $this->actingAs($this->user)->get('/api/v1/transactions/export');
+
+        $response->assertStatus(200);
+        $this->assertStringContainsString('text/csv', (string) $response->headers->get('content-type'));
+        $this->assertStringContainsString(
+            'attachment; filename="transactions',
+            (string) $response->headers->get('content-disposition')
+        );
+
+        $content = $response->getContent();
+        $this->assertStringContainsString('Weekly shop', $content);
+        $this->assertStringContainsString('Everyday', $content);
+        $this->assertStringContainsString('Groceries', $content);
+    }
+
+    public function test_transactions_export_renders_xlsx_and_pdf(): void
+    {
+        $this->createTransaction();
+
+        $xlsx = $this->actingAs($this->user)->get('/api/v1/transactions/export?format=xlsx');
+        $xlsx->assertStatus(200);
+        $this->assertStringContainsString('spreadsheetml', (string) $xlsx->headers->get('content-type'));
+        // An xlsx file is a zip archive; anything else means the writer failed.
+        $this->assertStringStartsWith('PK', $xlsx->getContent());
+
+        $pdf = $this->actingAs($this->user)->get('/api/v1/transactions/export?format=pdf');
+        $pdf->assertStatus(200);
+        $this->assertStringContainsString('application/pdf', (string) $pdf->headers->get('content-type'));
+        $this->assertStringStartsWith('%PDF', $pdf->getContent());
+    }
+
+    public function test_transactions_export_honours_the_same_filters_as_the_list(): void
+    {
+        $this->createTransaction(['description' => 'In range', 'datetime' => '2026-03-15T10:00:00.000Z']);
+        $this->createTransaction(['description' => 'Out of range', 'datetime' => '2026-01-05T10:00:00.000Z']);
+
+        $filters = 'date_from=2026-03-01&date_to=2026-03-31';
+
+        $list = $this->actingAs($this->user)->getJson("/api/v1/transactions?{$filters}");
+        $list->assertStatus(200);
+
+        $export = $this->actingAs($this->user)->get("/api/v1/transactions/export?{$filters}");
+        $export->assertStatus(200);
+
+        $content = $export->getContent();
+        $this->assertStringContainsString('In range', $content);
+        $this->assertStringNotContainsString('Out of range', $content);
+
+        $this->assertCount(1, $list->json('data.data'));
+    }
+
+    public function test_transactions_export_only_covers_the_authenticated_user(): void
+    {
+        $this->createTransaction(['description' => 'Mine']);
+
+        $other = User::factory()->create();
+        $otherWallet = $other->wallets()->create(['name' => 'Theirs', 'balance' => 0, 'currency' => 'USD']);
+        $this->actingAs($other)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 50,
+            'description' => 'Not mine',
+            'wallet_id' => $otherWallet->id,
+            'datetime' => '2026-03-15T10:00:00.000Z',
+        ])->assertStatus(201);
+
+        $content = $this->actingAs($this->user)->get('/api/v1/transactions/export')->getContent();
+
+        $this->assertStringContainsString('Mine', $content);
+        $this->assertStringNotContainsString('Not mine', $content);
+    }
+
+    public function test_export_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/transactions/export')->assertStatus(401);
+        $this->getJson('/api/v1/reports/export')->assertStatus(401);
+    }
+
+    public function test_unsupported_format_is_rejected(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/v1/transactions/export?format=docx');
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('success', false);
+        $this->assertContains('csv', $response->json('errors.supported_formats'));
+    }
+
+    public function test_report_export_renders_a_statement(): void
+    {
+        $this->createTransaction(['type' => 'income', 'amount' => 900, 'description' => 'Salary']);
+        $this->createTransaction(['type' => 'expense', 'amount' => 300, 'description' => 'Rent']);
+
+        $response = $this->actingAs($this->user)->get('/api/v1/reports/export?format=csv&preset=all_time');
+
+        $response->assertStatus(200);
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('Overview', $content);
+        $this->assertStringContainsString('Financial position', $content);
+        $this->assertStringContainsString('Total income', $content);
+    }
+
+    public function test_report_export_rejects_wallets_the_user_does_not_own(): void
+    {
+        $other = User::factory()->create();
+        $otherWallet = $other->wallets()->create(['name' => 'Theirs', 'balance' => 0, 'currency' => 'USD']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/v1/reports/export?wallet_ids={$otherWallet->id}");
+
+        $response->assertStatus(422);
+        $this->assertContains($otherWallet->id, $response->json('errors.invalid_wallet_ids'));
+    }
+
+    public function test_export_route_does_not_shadow_a_transaction_lookup(): void
+    {
+        $transaction = $this->createTransaction();
+
+        $response = $this->actingAs($this->user)->getJson("/api/v1/transactions/{$transaction['id']}");
+
+        $response->assertStatus(200);
+        $this->assertEquals($transaction['id'], $response->json('data.id'));
+    }
+}

--- a/tests/Feature/SchemaConformanceTest.php
+++ b/tests/Feature/SchemaConformanceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SchemaConformance\SchemaConformanceService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use Tests\TestCase;
+
+class SchemaConformanceTest extends TestCase
+{
+    /**
+     * Blueprint methods that define a column. Anything else a migration calls
+     * on the blueprint (index, foreign, drop*, modifiers) is not a column.
+     */
+    private const COLUMN_METHODS = [
+        'bigInteger', 'boolean', 'char', 'date', 'dateTime', 'decimal', 'double',
+        'enum', 'float', 'foreignId', 'integer', 'json', 'jsonb', 'longText',
+        'mediumText', 'smallInteger', 'string', 'text', 'time', 'timestamp',
+        'tinyInteger', 'unsignedBigInteger', 'unsignedInteger', 'unsignedSmallInteger',
+        'unsignedTinyInteger', 'uuid', 'year',
+    ];
+
+    public function test_the_declared_spec_matches_the_live_database(): void
+    {
+        $problems = app(SchemaConformanceService::class)->verify();
+
+        $this->assertSame(
+            [],
+            $problems,
+            'config/schema.php declares structures the database does not have: '
+                . implode(', ', array_column($problems, 'detail'))
+        );
+    }
+
+    /**
+     * A migration that alters an existing table can reach one environment and
+     * not another, leaving a table that looks intact but rejects writes. The
+     * conformance spec is what turns that into a clear 503 instead, so every
+     * altered column has to be declared there.
+     */
+    public function test_every_altered_column_is_declared_in_the_spec(): void
+    {
+        $declared = collect(config('schema.tables', []))
+            ->map(fn (array $spec) => array_keys($spec['columns'] ?? []));
+
+        $undeclared = [];
+
+        foreach ($this->alteredColumnsByTable() as $table => $columns) {
+            foreach ($columns as $column) {
+                if (! in_array($column, $declared->get($table, []), true)) {
+                    $undeclared[] = "{$table}.{$column}";
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $undeclared,
+            'These columns are added by an ALTER migration but are not declared in '
+                . 'config/schema.php, so schema:verify cannot detect them going missing: '
+                . implode(', ', $undeclared)
+        );
+    }
+
+    /**
+     * Catches the reverse gap: an attribute the model writes on every insert
+     * that no migration ever creates.
+     */
+    public function test_every_model_attribute_maps_to_a_real_column(): void
+    {
+        $missing = [];
+
+        foreach ($this->eloquentModels() as $model) {
+            $table = $model->getTable();
+
+            if (! Schema::hasTable($table)) {
+                $missing[] = $table . ' (table missing for ' . $model::class . ')';
+
+                continue;
+            }
+
+            $attributes = array_unique(array_merge(
+                $model->getFillable(),
+                array_keys($model->getAttributes())
+            ));
+
+            foreach ($attributes as $attribute) {
+                if (! Schema::hasColumn($table, $attribute)) {
+                    $missing[] = "{$table}.{$attribute} (" . $model::class . ')';
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $missing,
+            'These model attributes have no matching column: ' . implode(', ', $missing)
+        );
+    }
+
+    /**
+     * Columns added by `Schema::table(...)` blocks across the app's own
+     * migrations, keyed by table. Migrations written in a shape this does not
+     * recognise are skipped rather than reported, so the check never fails on
+     * an unusual but correct migration.
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function alteredColumnsByTable(): array
+    {
+        $byTable = [];
+
+        foreach (glob(database_path('migrations/*.php')) as $path) {
+            $contents = (string) file_get_contents($path);
+
+            // Everything after each `Schema::table('x'` up to the next one, so a
+            // file altering two tables attributes its columns to the right table.
+            $blocks = preg_split("/Schema::table\(\s*'/", $contents);
+            array_shift($blocks);
+
+            foreach ($blocks as $block) {
+                if (! preg_match("/^(\w+)'/", $block, $tableMatch)) {
+                    continue;
+                }
+
+                $methods = implode('|', self::COLUMN_METHODS);
+                preg_match_all("/\\\$table->({$methods})\(\s*'(\w+)'/", $block, $columnMatches);
+
+                foreach ($columnMatches[2] as $column) {
+                    $byTable[$tableMatch[1]][] = $column;
+                }
+            }
+        }
+
+        return array_map('array_unique', $byTable);
+    }
+
+    /**
+     * @return array<int, Model>
+     */
+    private function eloquentModels(): array
+    {
+        $models = [];
+
+        foreach (glob(app_path('Models/*.php')) as $path) {
+            $class = 'App\\Models\\' . Str::before(basename($path), '.php');
+
+            if (! class_exists($class) || ! is_subclass_of($class, Model::class)) {
+                continue;
+            }
+
+            if ((new ReflectionClass($class))->isAbstract()) {
+                continue;
+            }
+
+            $models[] = new $class();
+        }
+
+        return $models;
+    }
+}


### PR DESCRIPTION
Transaction writes fail on staging with `Unknown column 'intent'`. The migration exists; the database is behind, and the conformance check that should have caught it covered only reminders and budgets. Every column added by a later migration is now declared, so drift returns a 503 naming the column instead of failing at insert time, and the staging deploy verifies conformance. `reminders.source`, `remindable_type` and `remindable_id` turned out to have no migration at all; they now have one.

Separately: transactions and a period statement download as CSV, XLSX or PDF, reusing the listing's filters so a file matches the rows on screen. The mobile export buttons had nothing to call.

Staging still needs the migration run.