### PR TITLE
feat(deploy): Add self-contained compose stack for self-hosting

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -1,0 +1,126 @@
+# Trakli self-hosted environment configuration
+#
+# Copy this file to .env and edit the values below.
+# At minimum you must set:
+#   APP_KEY          — generate via: docker compose -f docker-compose.selfhost.yml run --rm app php artisan key:generate --show
+#   APP_URL          — your public API URL (e.g. https://api.example.com)
+#   CORS_ALLOWED_ORIGINS — your web UI's public origin (e.g. https://app.example.com)
+#   NUXT_PUBLIC_API_BASE_URL — APP_URL + /api/v1 (e.g. https://api.example.com/api/v1)
+#
+# Image tags are pinned to a specific release version — do NOT use 'latest'.
+# To upgrade, change the tag value and run: docker compose -f docker-compose.selfhost.yml up -d
+
+# ── Image versions ──────────────────────────────────────────────────────────
+IMAGE_TAG=v2.0.0-beta.1
+WEBUI_IMAGE_TAG=v2.0.0-beta.1
+
+# ── Application ─────────────────────────────────────────────────────────────
+APP_NAME=Trakli
+APP_ENV=production
+APP_KEY=
+APP_DEBUG=false
+APP_URL=http://localhost:8000
+
+LOG_CHANNEL=stack
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=error
+
+# ── Database (MySQL 8.0 — the only supported engine) ────────────────────────
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=trakli
+DB_USERNAME=trakli
+DB_PASSWORD=change-me-to-a-strong-password
+# Root password for the MySQL container — used only by the mysql service
+DB_ROOT_PASSWORD=change-me-to-a-strong-root-password
+
+# ── Cache & Queue ───────────────────────────────────────────────────────────
+BROADCAST_DRIVER=log
+CACHE_DRIVER=redis
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=redis
+SESSION_DRIVER=redis
+SESSION_LIFETIME=120
+
+REDIS_HOST=redis
+REDIS_PASSWORD=change-me-to-a-strong-redis-password
+REDIS_PORT=6379
+
+# ── Mail (defaults to log driver — override with your SMTP in production) ────
+MAIL_MAILER=log
+MAIL_HOST=null
+MAIL_PORT=2525
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS="noreply@localhost"
+MAIL_FROM_NAME="${APP_NAME}"
+
+# ── Frontend / Web UI ───────────────────────────────────────────────────────
+# CORS_ALLOWED_ORIGINS must be an EXACT string match of the web UI's public
+# origin — protocol, host, and port. E.g. "https://app.example.com" or
+# "http://localhost:3000" (no trailing slash). A mismatch causes a silent
+# CORS failure in the browser — the API returns data but the UI can't read it.
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+# NUXT_PUBLIC_API_BASE_URL is called by the browser (not the server), so this
+# must be the public URL where the API is reachable from outside Docker.
+# Format: <APP_URL>/api/v1
+NUXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+# Web UI port on the host (default 3000). The auth cookie (auth.token) is set
+# with the Secure flag in production — HTTPS is REQUIRED or login silently fails.
+WEBUI_PORT=3000
+
+# ── OAuth (optional — only needed if Google sign-in is enabled) ──────────────
+FRONTEND_URL=http://localhost:3000
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=${FRONTEND_URL}/auth/google/callback
+
+# ── Session / Sanctum (sane defaults — not used by the web UI bearer flow) ───
+SANCTUM_STATEFUL_DOMAINS=localhost,localhost:3000
+SESSION_DOMAIN=localhost
+
+# ── User Authentication ─────────────────────────────────────────────────────
+USER_AUTH_REQUIRE_EMAIL_VERIFICATION=true
+USER_AUTH_REQUIRE_PHONE_VERIFICATION=false
+USER_AUTH_CODE_LENGTH=6
+USER_AUTH_CODE_EXPIRY_MINUTES=5
+USER_AUTH_RATE_LIMIT_ATTEMPTS=3
+USER_AUTH_RATE_LIMIT_MINUTES=5
+USER_AUTH_VERIFICATION_PROVIDER=smartpings
+USER_AUTH_SELF_MANAGED=false
+USER_AUTH_ROUTE_PREFIX=api/v1
+MODEL_CONFIG_ROUTE_PREFIX=api/v1
+
+# ── SmartPings ──────────────────────────────────────────────────────────────
+SMARTPINGS_CLIENT_ID=
+SMARTPINGS_SECRET_ID=
+
+# ── Firebase (optional) ─────────────────────────────────────────────────────
+FIREBASE_CREDENTIALS=storage/app/firebase-auth.json
+
+# ── MCP ─────────────────────────────────────────────────────────────────────
+MCP_ENABLED=false
+MCP_ENDPOINT=mcp
+MCP_AUTH_GUARD=sanctum
+MCP_RATE_LIMIT_ENABLED=true
+MCP_RATE_LIMIT_MAX=60
+MCP_RATE_LIMIT_DECAY=1
+MCP_STRICT_PERMISSIONS=false
+
+# ── Agent token-usage metrics ───────────────────────────────────────────────
+TOKEN_USAGE_REGISTER_ROUTES=false
+
+# ── AI profile only (--profile ai) ──────────────────────────────────────────
+# Uncomment these if running with --profile ai:
+# GEMINI_API_KEY=
+# LLM_API_KEY=
+# SMARTQL_URL=http://smartql:8080
+
+# ── Realtime profile only (--profile realtime) ──────────────────────────────
+# Uncomment these if running with --profile realtime:
+# REVERB_APP_KEY=
+# REVERB_APP_HOST=localhost
+# REVERB_PORT=6001
+# REVERB_SCHEME=http

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A full finance app, not a spreadsheet:
 - Make
 
 ### Quick installation guide
-- `git clone git@github.com:whilesmart/trakli-webservice.git`
+- `git clone git@github.com:trakli/trakli-webservice.git`
 - `cd trakli-webservice`
 - `cp .env.example .env`
 - `make setup`

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,0 +1,178 @@
+# Trakli self-contained stack — for self-hosting only.
+#
+# This file ships the full stack (app, worker, web UI, database, cache) and
+# comes up with a single command and no file editing beyond copying the
+# example env file.
+#
+# docker-compose.prod.yml remains the BYO-database / hosted pipeline path
+# and is NOT modified by this file.
+#
+# Quick start:
+#   cp .env.selfhost.example .env
+#   # edit .env — at minimum set APP_KEY, APP_URL, CORS_ALLOWED_ORIGINS,
+#   #            and NUXT_PUBLIC_API_BASE_URL to match your public URL
+#   docker compose -f docker-compose.selfhost.yml up -d
+#
+# Optional profiles:
+#   docker compose -f docker-compose.selfhost.yml --profile ai up -d
+#   docker compose -f docker-compose.selfhost.yml --profile realtime up -d
+#
+# HTTPS is REQUIRED in production — the web UI auth cookie (auth.token) is
+# set with the Secure flag and will silently fail over plain HTTP.
+
+name: trakli
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: trakli-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${DB_DATABASE:-trakli}
+      MYSQL_USER: ${DB_USERNAME:-trakli}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    command: --default-authentication-plugin=mysql_native_password
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - trakli
+
+  redis:
+    image: redis:alpine
+    container_name: trakli-redis
+    restart: unless-stopped
+    command: redis-server --requirepass "${REDIS_PASSWORD}"
+    environment:
+      - REDIS_PASSWORD
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - redis_data:/data
+    networks:
+      - trakli
+
+  migrate:
+    image: ghcr.io/trakli/webservice:${IMAGE_TAG}
+    container_name: trakli-migrate
+    restart: "no"
+    command: php artisan migrate --force
+    depends_on:
+      mysql:
+        condition: service_healthy
+    env_file: .env
+    networks:
+      - trakli
+
+  app:
+    image: ghcr.io/trakli/webservice:${IMAGE_TAG}
+    container_name: trakli-app
+    restart: unless-stopped
+    volumes:
+      - ./storage:/var/www/html/storage
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    env_file: .env
+    # CORS_ALLOWED_ORIGINS (in .env) must exactly match the webui's public
+    # origin — protocol + host, no trailing slash. A mismatch causes the
+    # browser to silently reject API responses.
+    networks:
+      - trakli
+
+  worker:
+    image: ghcr.io/trakli/webservice:${IMAGE_TAG}
+    container_name: trakli-worker
+    restart: unless-stopped
+    command: php artisan queue:work --tries=3 --timeout=300 --sleep=3
+    volumes:
+      - ./storage:/var/www/html/storage
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    env_file: .env
+    networks:
+      - trakli
+
+  webui:
+    image: ghcr.io/trakli/webui:${WEBUI_IMAGE_TAG}
+    container_name: trakli-webui
+    restart: unless-stopped
+    ports:
+      - "${WEBUI_PORT:-3000}:3000"
+    environment:
+      # Must be the public URL the browser uses to reach the API — not the
+      # internal Docker DNS name. E.g. https://api.example.com/api/v1
+      - NUXT_PUBLIC_API_BASE_URL
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    networks:
+      - trakli
+
+  smartql:
+    image: ghcr.io/trakli/webservice:${IMAGE_TAG}
+    container_name: trakli-smartql
+    restart: unless-stopped
+    command: php artisan smartql:serve
+    profiles:
+      - ai
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    env_file: .env
+    networks:
+      - trakli
+
+  reverb:
+    image: ghcr.io/trakli/webservice:${IMAGE_TAG}
+    container_name: trakli-reverb
+    restart: unless-stopped
+    command: php artisan reverb:start
+    ports:
+      - "${REVERB_PORT:-6001}:6001"
+    profiles:
+      - realtime
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    env_file: .env
+    networks:
+      - trakli
+
+networks:
+  trakli:
+    driver: bridge
+
+volumes:
+  mysql_data:
+    driver: local
+  redis_data:
+    driver: local


### PR DESCRIPTION
## What

Adds `docker-compose.selfhost.yml` and `.env.selfhost.example` so the full Trakli stack (app, worker, web UI, database, cache) comes up with a single command and no file editing.

This is PR 1 of [Issue #308](https://github.com/trakli/webservice/issues/308) — Distribution, Helm, Cloud Templates.

## Stack shape

| Service | Image | Key config |
|---|---|---|
| mysql | mysql:8.0 | healthchecked, persistent volume |
| redis | redis:alpine | password-protected, persistent volume |
| migrate | ghcr.io/trakli/webservice:${IMAGE_TAG} | one-shot, depends on mysql healthy |
| app | ghcr.io/trakli/webservice:${IMAGE_TAG} | depends on migrate completed + redis healthy |
| worker | ghcr.io/trakli/webservice:${IMAGE_TAG} | queue:work, same dependencies |
| webui | ghcr.io/trakli/webui:${WEBUI_IMAGE_TAG} | port 3000, Nuxt frontend |
| smartql | (profile: ai) | optional, off by default |
| reverb | (profile: realtime) | optional, off by default |

## What this does NOT touch

- `docker-compose.prod.yml` — remains the BYO-database / hosted pipeline path, unchanged.

## Quick start

```bash
cp .env.selfhost.example .env
# edit .env — at minimum set APP_KEY, APP_URL, CORS_ALLOWED_ORIGINS, NUXT_PUBLIC_API_BASE_URL
docker compose -f docker-compose.selfhost.yml up -d
```

## Key decisions

- **Image tags pinned to semver** (`v2.0.0-beta.1`), never `latest` — upgrade by changing the tag
- **Migrate is a one-shot service** with `restart: "no"` (docker/compose#9260 workaround)
- **HTTPS required** for webui — auth cookie is set with Secure flag, login silently fails over HTTP
- **CORS_ALLOWED_ORIGINS** must exactly match the webui's public origin (protocol + host)

## Checklist

- [ ] Image tags pinned to semver, not `latest`
- [ ] No secrets committed
- [ ] `docker compose up -d` reaches healthy app within 90s
- [ ] Migrate exits 0 once (not restarting)
- [ ] Register + create transaction via API end-to-end