### PR TITLE
feat(admin): Add user engagement insights

### DIFF
--- a/app/Engagement/AgentUsageMetricProvider.php
+++ b/app/Engagement/AgentUsageMetricProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Engagement;
+
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Whilesmart\AgentMetrics\Models\TokenUsage;
+use Whilesmart\Engagement\Contracts\MetricProvider;
+use Whilesmart\Engagement\Support\Metric;
+use Whilesmart\Engagement\Support\Period;
+
+class AgentUsageMetricProvider implements MetricProvider
+{
+    public function key(): string
+    {
+        return 'agent_usage';
+    }
+
+    public function label(): string
+    {
+        return 'AI usage';
+    }
+
+    public function metrics(Period $period): array
+    {
+        $usage = TokenUsage::query()
+            ->whereBetween('created_at', [$period->start, $period->end])
+            ->get(['owner_type', 'owner_id', 'total_tokens', 'created_at']);
+
+        return [
+            Metric::sum('ai_tokens_used', 'AI tokens used', (float) $usage->sum('total_tokens'), 'tokens'),
+            Metric::series('ai_tokens_series', 'AI tokens over time', $this->series($usage, $period), 'tokens'),
+            Metric::ranking('ai_tokens_by_user', 'AI tokens by user', $this->ranking($usage)),
+        ];
+    }
+
+    private function series(iterable $usage, Period $period): array
+    {
+        $format = $period->bucketFormat();
+        $totals = [];
+
+        foreach ($usage as $row) {
+            $bucket = CarbonImmutable::parse($row->created_at)->format($format);
+            $totals[$bucket] = ($totals[$bucket] ?? 0) + $row->total_tokens;
+        }
+
+        return collect($period->buckets())
+            ->map(fn ($bucket) => [
+                'date' => $bucket->format($format),
+                'value' => $totals[$bucket->format($format)] ?? 0,
+            ])
+            ->all();
+    }
+
+    private function ranking(iterable $usage): array
+    {
+        $userType = (new User())->getMorphClass();
+        $totals = collect($usage)
+            ->where('owner_type', $userType)
+            ->groupBy('owner_id')
+            ->map(fn ($rows) => (int) $rows->sum('total_tokens'))
+            ->sortDesc()
+            ->take(8);
+        $users = User::query()->whereIn('id', $totals->keys())->get()->keyBy('id');
+
+        return $totals->map(function (int $tokens, int|string $userId) use ($users) {
+            $user = $users->get($userId);
+            $name = $user
+                ? trim(sprintf(
+                    '%s %s',
+                    (string) $user->getAttribute('first_name'),
+                    (string) $user->getAttribute('last_name')
+                ))
+                : '';
+
+            return [
+                'label' => $user ? ($name ?: $user->getAttribute('email')) : "User {$userId}",
+                'value' => $tokens,
+            ];
+        })->values()->all();
+    }
+}

--- a/app/Http/Controllers/API/v1/Admin/UserController.php
+++ b/app/Http/Controllers/API/v1/Admin/UserController.php
@@ -20,6 +20,8 @@ class UserController extends ApiController
         tags: ['Admin'],
         parameters: [
             new OA\Parameter(name: 'search', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'joined_on', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1)),
             new OA\Parameter(name: 'per_page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 15)),
         ],
         responses: [
@@ -30,8 +32,18 @@ class UserController extends ApiController
     )]
     public function index(Request $request): JsonResponse
     {
-        $query = User::query();
-        $search = $request->input('search');
+        $validated = $request->validate([
+            'search' => ['nullable', 'string', 'max:255'],
+            'joined_on' => ['nullable', 'date_format:Y-m-d'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $query = User::query()
+            ->withSum('tokenUsages as tokens_used', 'total_tokens')
+            ->withMax('tokens as last_seen_at', 'last_used_at')
+            ->withMax('transactions as last_transaction_at', 'datetime')
+            ->latest('created_at');
+        $search = $validated['search'] ?? null;
 
         if ($search) {
             $query->where(function ($q) use ($search) {
@@ -42,7 +54,11 @@ class UserController extends ApiController
             });
         }
 
-        $users = $query->paginate($request->input('per_page', 15));
+        if (isset($validated['joined_on'])) {
+            $query->whereDate('created_at', $validated['joined_on']);
+        }
+
+        $users = $query->paginate($validated['per_page'] ?? 15);
 
         return $this->success($users);
     }
@@ -79,7 +95,7 @@ class UserController extends ApiController
         ];
 
         return $this->success([
-            'user' => $user,
+            'user' => array_merge($user->toArray(), ['tokens_used' => $user->tokensUsed()]),
             'counts' => $counts,
             'preferences' => [
                 'country' => $user->getConfigValue('country'),
@@ -121,8 +137,8 @@ class UserController extends ApiController
         }
 
         $email = $user->email;
-        $name = $user->first_name . ' ' . $user->last_name;
-        $adminName = $request->user()->first_name . ' ' . $request->user()->last_name;
+        $name = sprintf('%s %s', $user->first_name, $user->last_name);
+        $adminName = sprintf('%s %s', $request->user()->first_name, $request->user()->last_name);
         $reason = $request->input('reason', 'No reason provided');
 
         $user->tokens()->delete();

--- a/app/Jobs/GenerateChatTitleJob.php
+++ b/app/Jobs/GenerateChatTitleJob.php
@@ -38,7 +38,8 @@ class GenerateChatTitleJob implements ShouldQueue
         }
 
         $this->session->update([
-            'title' => $router->generateTitle($this->firstQuestion) ?? Str::limit($this->firstQuestion, 60),
+            'title' => $router->generateTitle($this->firstQuestion, $this->session->owner)
+                ?? Str::limit($this->firstQuestion, 60),
         ]);
     }
 }

--- a/app/Jobs/ProcessChatMessageJob.php
+++ b/app/Jobs/ProcessChatMessageJob.php
@@ -62,7 +62,11 @@ class ProcessChatMessageJob implements ShouldQueue
         // judged in isolation and misrouted.
         $route = $userMessage->files()->exists()
             ? AiRouter::ROUTE_AGENT
-            : $router->classify($userMessage->content, $this->recentConversation($userMessage));
+            : $router->classify(
+                $userMessage->content,
+                $this->recentConversation($userMessage),
+                $this->owner(),
+            );
 
         if ($route === AiRouter::ROUTE_GENERAL) {
             $this->answerGeneral($router, $userMessage->content);
@@ -234,7 +238,7 @@ class ProcessChatMessageJob implements ShouldQueue
 
     private function answerGeneral(AiRouter $router, string $question, ?string $hint = null): void
     {
-        $answer = $router->answerGeneral($question, $hint);
+        $answer = $router->answerGeneral($question, $hint, $this->owner());
 
         if (! $answer['success']) {
             $this->markFailed($answer['error']);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,11 +10,11 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Whilesmart\AgentActions\Traits\HasAgentActions;
 use Whilesmart\AgentMetrics\Traits\HasTokenUsage;
 use Whilesmart\ModelConfiguration\Traits\Configurable;
 use Whilesmart\Outreach\Traits\SendsOutreach;
 use Whilesmart\Roles\Traits\HasRoles;
-use Whilesmart\AgentActions\Traits\HasAgentActions;
 use Whilesmart\UserDevices\Traits\HasDevices;
 
 class User extends Authenticatable implements HasLocalePreference
@@ -22,10 +22,10 @@ class User extends Authenticatable implements HasLocalePreference
     use Configurable;
     use HasAgentActions;
     use HasApiTokens;
-    use HasTokenUsage;
     use HasDevices;
     use HasFactory;
     use HasRoles;
+    use HasTokenUsage;
     use Notifiable;
     use SendsOutreach;
 
@@ -72,6 +72,7 @@ class User extends Authenticatable implements HasLocalePreference
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
+        'tokens_used' => 'integer',
     ];
 
     public function categories(): HasMany

--- a/app/Services/AiRouter.php
+++ b/app/Services/AiRouter.php
@@ -2,10 +2,14 @@
 
 namespace App\Services;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Prism\Prism\Facades\Prism;
+use Prism\Prism\ValueObjects\Usage;
 use Throwable;
+use Whilesmart\AgentMetrics\Facades\TokenMeter;
+use Whilesmart\Entitlements\Contracts\Entitlements;
 
 class AiRouter
 {
@@ -15,7 +19,7 @@ class AiRouter
 
     public const ROUTE_AGENT = 'agent';
 
-    public function classify(string $question, string $conversation = ''): string
+    public function classify(string $question, string $conversation = '', ?Model $owner = null): string
     {
         try {
             $prompt = trim($conversation) !== ''
@@ -31,6 +35,8 @@ class AiRouter
                 ->withPrompt($prompt)
                 ->usingTemperature(0)
                 ->asText();
+
+            $this->recordTokenUsage($owner, $response->usage, 'chat.classify');
 
             $label = strtolower(trim($response->text, " \t\n\r\0\x0B\"'.,"));
             $route = match ($label) {
@@ -55,8 +61,11 @@ class AiRouter
         }
     }
 
-    public function answerGeneral(string $question, ?string $dataFailureHint = null): array
-    {
+    public function answerGeneral(
+        string $question,
+        ?string $dataFailureHint = null,
+        ?Model $owner = null,
+    ): array {
         try {
             $response = Prism::text()
                 ->using(
@@ -67,6 +76,8 @@ class AiRouter
                 ->withPrompt($question)
                 ->usingTemperature(0.3)
                 ->asText();
+
+            $this->recordTokenUsage($owner, $response->usage, 'chat.general');
 
             return [
                 'success' => true,
@@ -82,7 +93,7 @@ class AiRouter
         }
     }
 
-    public function generateTitle(string $firstQuestion): ?string
+    public function generateTitle(string $firstQuestion, ?Model $owner = null): ?string
     {
         try {
             $response = Prism::text()
@@ -94,6 +105,8 @@ class AiRouter
                 ->withPrompt($firstQuestion)
                 ->usingTemperature(0.3)
                 ->asText();
+
+            $this->recordTokenUsage($owner, $response->usage, 'chat.title');
 
             $title = trim($response->text);
             $title = trim($title, "\"'.,;:!?\n\r\t ");
@@ -108,6 +121,30 @@ class AiRouter
 
             return null;
         }
+    }
+
+    private function recordTokenUsage(?Model $owner, Usage $usage, string $operation): void
+    {
+        if ($owner === null) {
+            return;
+        }
+
+        $values = $usage->toArray();
+        $tokens = (int) ($values['prompt_tokens'] ?? 0)
+            + (int) ($values['completion_tokens'] ?? 0);
+
+        if ($tokens <= 0) {
+            return;
+        }
+
+        app(Entitlements::class)->consume($owner, 'ai_tokens', $tokens);
+        TokenMeter::record(
+            owner: $owner,
+            provider: (string) config('services.llm.provider'),
+            model: (string) config('services.llm.model'),
+            usage: $values,
+            operation: $operation,
+        );
     }
 
     private function classifierSystemPrompt(): string

--- a/config/engagement.php
+++ b/config/engagement.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Engagement\AccountsMetricProvider;
+use App\Engagement\AgentUsageMetricProvider;
 use App\Engagement\DemographicsMetricProvider;
 use App\Engagement\EngagementMetricProvider;
 use App\Engagement\TransactionsMetricProvider;
@@ -21,5 +22,6 @@ return [
         EngagementMetricProvider::class,
         DemographicsMetricProvider::class,
         AccountsMetricProvider::class,
+        AgentUsageMetricProvider::class,
     ],
 ];

--- a/public/docs/api.json
+++ b/public/docs/api.json
@@ -247,6 +247,24 @@
                         }
                     },
                     {
+                        "name": "joined_on",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    },
+                    {
                         "name": "per_page",
                         "in": "query",
                         "required": false,

--- a/tests/Feature/AdminMetricsControllerTest.php
+++ b/tests/Feature/AdminMetricsControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Whilesmart\AgentMetrics\Facades\TokenMeter;
 use Whilesmart\Roles\Models\Role;
 
 class AdminMetricsControllerTest extends TestCase
@@ -33,6 +34,10 @@ class AdminMetricsControllerTest extends TestCase
                 'datetime' => now()->subDays(2),
             ]);
         }
+        TokenMeter::record($this->admin, 'gemini', 'gemini-flash-latest', [
+            'prompt_tokens' => 120,
+            'completion_tokens' => 30,
+        ]);
 
         $response = $this->actingAs($this->admin)->getJson('/api/v1/admin/metrics?days=30');
 
@@ -62,6 +67,11 @@ class AdminMetricsControllerTest extends TestCase
         $this->assertSame('ranking', $features['type']);
         $this->assertNotEmpty($features['rows']);
         $this->assertSame('Transactions', $features['rows'][0]['label']);
+
+        $usage = collect($groups['agent_usage']['metrics'])->keyBy('key');
+        $this->assertSame(150, $usage['ai_tokens_used']['value']);
+        $this->assertSame(150, collect($usage['ai_tokens_series']['series'])->sum('value'));
+        $this->assertSame(150, $usage['ai_tokens_by_user']['rows'][0]['value']);
     }
 
     public function test_non_admin_is_forbidden(): void

--- a/tests/Feature/AdminUserControllerTest.php
+++ b/tests/Feature/AdminUserControllerTest.php
@@ -3,10 +3,12 @@
 namespace Tests\Feature;
 
 use App\Events\AccountDeleted;
+use App\Models\Transaction;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
+use Whilesmart\AgentMetrics\Facades\TokenMeter;
 use Whilesmart\Roles\Models\Role;
 
 class AdminUserControllerTest extends TestCase
@@ -37,14 +39,61 @@ class AdminUserControllerTest extends TestCase
 
     public function test_admin_can_search_users()
     {
-        $response = $this->actingAs($this->admin)->getJson('/api/v1/admin/users?search=' . $this->user->email);
+        $response = $this->actingAs($this->admin)->getJson('/api/v1/admin/users?search='.$this->user->email);
 
         $response->assertStatus(200);
     }
 
+    public function test_admin_can_paginate_and_filter_users_by_join_date(): void
+    {
+        User::factory()->count(6)->create(['created_at' => '2026-08-10 12:00:00']);
+        User::factory()->count(2)->create(['created_at' => '2026-08-11 12:00:00']);
+
+        $response = $this->actingAs($this->admin)
+            ->getJson('/api/v1/admin/users?joined_on=2026-08-10&per_page=5&page=2');
+
+        $response->assertOk()
+            ->assertJsonPath('data.current_page', 2)
+            ->assertJsonPath('data.per_page', 5)
+            ->assertJsonPath('data.total', 6)
+            ->assertJsonCount(1, 'data.data');
+    }
+
+    public function test_admin_user_list_includes_existing_activity_data(): void
+    {
+        $token = $this->user->createToken('admin-insight')->accessToken;
+        $token->forceFill(['last_used_at' => '2026-08-18 12:34:00'])->save();
+        Transaction::factory()->withUserAndWallet($this->user)->create([
+            'datetime' => '2026-08-17 10:00:00',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->getJson('/api/v1/admin/users?search='.$this->user->email);
+
+        $response->assertOk()
+            ->assertJsonPath('data.data.0.last_seen_at', '2026-08-18 12:34:00')
+            ->assertJsonPath('data.data.0.last_transaction_at', '2026-08-17 10:00:00');
+    }
+
+    public function test_admin_user_list_and_detail_include_token_usage(): void
+    {
+        TokenMeter::record($this->user, 'gemini', 'gemini-flash-latest', [
+            'prompt_tokens' => 120,
+            'completion_tokens' => 30,
+        ]);
+
+        $list = $this->actingAs($this->admin)
+            ->getJson('/api/v1/admin/users?search='.$this->user->email);
+        $detail = $this->actingAs($this->admin)
+            ->getJson('/api/v1/admin/users/'.$this->user->id);
+
+        $list->assertOk()->assertJsonPath('data.data.0.tokens_used', 150);
+        $detail->assertOk()->assertJsonPath('data.user.tokens_used', 150);
+    }
+
     public function test_admin_can_show_user()
     {
-        $response = $this->actingAs($this->admin)->getJson('/api/v1/admin/users/' . $this->user->id);
+        $response = $this->actingAs($this->admin)->getJson('/api/v1/admin/users/'.$this->user->id);
 
         $response->assertStatus(200)
             ->assertJson(['success' => true]);
@@ -61,7 +110,7 @@ class AdminUserControllerTest extends TestCase
     {
         Event::fake([AccountDeleted::class]);
 
-        $response = $this->actingAs($this->admin)->deleteJson('/api/v1/admin/users/' . $this->user->id, [
+        $response = $this->actingAs($this->admin)->deleteJson('/api/v1/admin/users/'.$this->user->id, [
             'reason' => 'Policy violation',
         ]);
 

--- a/tests/Feature/AgentMetricsTest.php
+++ b/tests/Feature/AgentMetricsTest.php
@@ -11,11 +11,46 @@ use App\Services\AiRouter;
 use App\Services\AiService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
+use Prism\Prism\Enums\FinishReason;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Text\Response as TextResponse;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\Usage;
 use Tests\TestCase;
 
 class AgentMetricsTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_routing_a_chat_turn_records_token_usage_for_the_owner(): void
+    {
+        $user = User::factory()->create();
+
+        Prism::fake([
+            new TextResponse(
+                steps: collect([]),
+                text: AiRouter::ROUTE_DATA,
+                finishReason: FinishReason::Stop,
+                toolCalls: [],
+                toolResults: [],
+                usage: new Usage(24, 1),
+                meta: new Meta('fake', 'fake'),
+                messages: collect([]),
+            ),
+        ]);
+
+        $route = app(AiRouter::class)->classify('How much did I spend?', '', $user);
+
+        $this->assertSame(AiRouter::ROUTE_DATA, $route);
+        $this->assertDatabaseHas('token_usages', [
+            'owner_type' => $user->getMorphClass(),
+            'owner_id' => $user->id,
+            'operation' => 'chat.classify',
+            'prompt_tokens' => 24,
+            'completion_tokens' => 1,
+        ]);
+        $this->assertSame(25, $user->fresh()->tokensUsed());
+    }
 
     public function test_an_agent_turn_records_token_usage_for_the_owner(): void
     {

--- a/tests/Feature/AiChatTest.php
+++ b/tests/Feature/AiChatTest.php
@@ -279,7 +279,7 @@ class AiChatTest extends TestCase
         $router->shouldReceive('classify')->once()
             ->with('Main Checking', Mockery::on(
                 fn ($conversation) => is_string($conversation) && str_contains($conversation, 'Which wallet')
-            ))
+            ), Mockery::type(\Illuminate\Database\Eloquent\Model::class))
             ->andReturn(AiRouter::ROUTE_AGENT);
         $router->shouldReceive('generateTitle')->andReturn(null);
 
@@ -358,7 +358,11 @@ class AiChatTest extends TestCase
 
         $router = Mockery::mock(AiRouter::class);
         $router->shouldReceive('classify')->once()->andReturn(AiRouter::ROUTE_GENERAL);
-        $router->shouldReceive('answerGeneral')->once()->with('What does expense mean?', null)
+        $router->shouldReceive('answerGeneral')->once()->with(
+            'What does expense mean?',
+            null,
+            Mockery::type(\Illuminate\Database\Eloquent\Model::class),
+        )
             ->andReturn(['success' => true, 'text' => 'An expense is money you spend.']);
         $router->shouldReceive('generateTitle')->andReturn('Definition of expense');
 


### PR DESCRIPTION
Provides the admin console with searchable, paginated user engagement and AI usage data. Token totals now cover both routing and agent work, while activity comes from existing Sanctum and transaction records without a user schema change.